### PR TITLE
Make the module compatable with latest matplotlib version

### DIFF
--- a/colormaps/cmaps.py
+++ b/colormaps/cmaps.py
@@ -5,6 +5,7 @@ import re
 from glob import glob
 
 import matplotlib.cm
+import matplotlib.pyplot as plt
 import numpy as np
 
 # from ._version import __version__
@@ -68,7 +69,7 @@ class Cmaps(object):
     @property
     def aggrnyl(self):
         cname = "aggrnyl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "aggrnyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -78,7 +79,7 @@ class Cmaps(object):
     @property
     def aggrnyl_r(self):
         cname = "aggrnyl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "aggrnyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -88,7 +89,7 @@ class Cmaps(object):
     @property
     def agsunset(self):
         cname = "agsunset"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "agsunset.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -98,7 +99,7 @@ class Cmaps(object):
     @property
     def agsunset_r(self):
         cname = "agsunset_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "agsunset.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -108,7 +109,7 @@ class Cmaps(object):
     @property
     def antique(self):
         cname = "antique"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "antique.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -118,7 +119,7 @@ class Cmaps(object):
     @property
     def antique_r(self):
         cname = "antique_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "antique.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -128,7 +129,7 @@ class Cmaps(object):
     @property
     def armyrose(self):
         cname = "armyrose"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "armyrose.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -138,7 +139,7 @@ class Cmaps(object):
     @property
     def armyrose_r(self):
         cname = "armyrose_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "armyrose.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -148,7 +149,7 @@ class Cmaps(object):
     @property
     def blugrn(self):
         cname = "blugrn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "blugrn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -158,7 +159,7 @@ class Cmaps(object):
     @property
     def blugrn_r(self):
         cname = "blugrn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "blugrn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -168,7 +169,7 @@ class Cmaps(object):
     @property
     def bluyl(self):
         cname = "bluyl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "bluyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -178,7 +179,7 @@ class Cmaps(object):
     @property
     def bluyl_r(self):
         cname = "bluyl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "bluyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -188,7 +189,7 @@ class Cmaps(object):
     @property
     def bold(self):
         cname = "bold"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "bold.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -198,7 +199,7 @@ class Cmaps(object):
     @property
     def bold_r(self):
         cname = "bold_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "bold.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -208,7 +209,7 @@ class Cmaps(object):
     @property
     def brwnyl(self):
         cname = "brwnyl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "brwnyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -218,7 +219,7 @@ class Cmaps(object):
     @property
     def brwnyl_r(self):
         cname = "brwnyl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "brwnyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -228,7 +229,7 @@ class Cmaps(object):
     @property
     def burg(self):
         cname = "burg"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "burg.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -238,7 +239,7 @@ class Cmaps(object):
     @property
     def burg_r(self):
         cname = "burg_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "burg.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -248,7 +249,7 @@ class Cmaps(object):
     @property
     def burgyl(self):
         cname = "burgyl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "burgyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -258,7 +259,7 @@ class Cmaps(object):
     @property
     def burgyl_r(self):
         cname = "burgyl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "burgyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -268,7 +269,7 @@ class Cmaps(object):
     @property
     def darkmint(self):
         cname = "darkmint"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "darkmint.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -278,7 +279,7 @@ class Cmaps(object):
     @property
     def darkmint_r(self):
         cname = "darkmint_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "darkmint.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -288,7 +289,7 @@ class Cmaps(object):
     @property
     def earth(self):
         cname = "earth"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "earth.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -298,7 +299,7 @@ class Cmaps(object):
     @property
     def earth_r(self):
         cname = "earth_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "earth.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -308,7 +309,7 @@ class Cmaps(object):
     @property
     def emrld(self):
         cname = "emrld"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "emrld.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -318,7 +319,7 @@ class Cmaps(object):
     @property
     def emrld_r(self):
         cname = "emrld_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "emrld.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -328,7 +329,7 @@ class Cmaps(object):
     @property
     def fall(self):
         cname = "fall"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "fall.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -338,7 +339,7 @@ class Cmaps(object):
     @property
     def fall_r(self):
         cname = "fall_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "fall.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -348,7 +349,7 @@ class Cmaps(object):
     @property
     def geyser(self):
         cname = "geyser"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "geyser.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -358,7 +359,7 @@ class Cmaps(object):
     @property
     def geyser_r(self):
         cname = "geyser_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "geyser.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -368,7 +369,7 @@ class Cmaps(object):
     @property
     def magenta(self):
         cname = "magenta"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "magenta.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -378,7 +379,7 @@ class Cmaps(object):
     @property
     def magenta_r(self):
         cname = "magenta_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "magenta.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -388,7 +389,7 @@ class Cmaps(object):
     @property
     def mint(self):
         cname = "mint"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "mint.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -398,7 +399,7 @@ class Cmaps(object):
     @property
     def mint_r(self):
         cname = "mint_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "mint.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -408,7 +409,7 @@ class Cmaps(object):
     @property
     def oryel(self):
         cname = "oryel"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "oryel.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -418,7 +419,7 @@ class Cmaps(object):
     @property
     def oryel_r(self):
         cname = "oryel_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "oryel.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -428,7 +429,7 @@ class Cmaps(object):
     @property
     def pastel(self):
         cname = "pastel"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "pastel.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -438,7 +439,7 @@ class Cmaps(object):
     @property
     def pastel_r(self):
         cname = "pastel_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "pastel.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -448,7 +449,7 @@ class Cmaps(object):
     @property
     def peach(self):
         cname = "peach"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "peach.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -458,7 +459,7 @@ class Cmaps(object):
     @property
     def peach_r(self):
         cname = "peach_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "peach.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -468,7 +469,7 @@ class Cmaps(object):
     @property
     def pinkyl(self):
         cname = "pinkyl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "pinkyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -478,7 +479,7 @@ class Cmaps(object):
     @property
     def pinkyl_r(self):
         cname = "pinkyl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "pinkyl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -488,7 +489,7 @@ class Cmaps(object):
     @property
     def prism(self):
         cname = "prism"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "prism.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -498,7 +499,7 @@ class Cmaps(object):
     @property
     def prism_r(self):
         cname = "prism_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "prism.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -508,7 +509,7 @@ class Cmaps(object):
     @property
     def purp(self):
         cname = "purp"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "purp.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -518,7 +519,7 @@ class Cmaps(object):
     @property
     def purp_r(self):
         cname = "purp_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "purp.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -528,7 +529,7 @@ class Cmaps(object):
     @property
     def purpor(self):
         cname = "purpor"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "purpor.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -538,7 +539,7 @@ class Cmaps(object):
     @property
     def purpor_r(self):
         cname = "purpor_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "purpor.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -548,7 +549,7 @@ class Cmaps(object):
     @property
     def redor(self):
         cname = "redor"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "redor.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -558,7 +559,7 @@ class Cmaps(object):
     @property
     def redor_r(self):
         cname = "redor_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "redor.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -568,7 +569,7 @@ class Cmaps(object):
     @property
     def safe(self):
         cname = "safe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "safe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -578,7 +579,7 @@ class Cmaps(object):
     @property
     def safe_r(self):
         cname = "safe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "safe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -588,7 +589,7 @@ class Cmaps(object):
     @property
     def sunset(self):
         cname = "sunset"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "sunset.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -598,7 +599,7 @@ class Cmaps(object):
     @property
     def sunset_r(self):
         cname = "sunset_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "sunset.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -608,7 +609,7 @@ class Cmaps(object):
     @property
     def sunsetdark(self):
         cname = "sunsetdark"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "sunsetdark.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -618,7 +619,7 @@ class Cmaps(object):
     @property
     def sunsetdark_r(self):
         cname = "sunsetdark_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "sunsetdark.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -628,7 +629,7 @@ class Cmaps(object):
     @property
     def teal(self):
         cname = "teal"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "teal.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -638,7 +639,7 @@ class Cmaps(object):
     @property
     def teal_r(self):
         cname = "teal_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "teal.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -648,7 +649,7 @@ class Cmaps(object):
     @property
     def tealgrn(self):
         cname = "tealgrn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "tealgrn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -658,7 +659,7 @@ class Cmaps(object):
     @property
     def tealgrn_r(self):
         cname = "tealgrn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "tealgrn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -668,7 +669,7 @@ class Cmaps(object):
     @property
     def tealrose(self):
         cname = "tealrose"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "tealrose.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -678,7 +679,7 @@ class Cmaps(object):
     @property
     def tealrose_r(self):
         cname = "tealrose_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "tealrose.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -688,7 +689,7 @@ class Cmaps(object):
     @property
     def temps(self):
         cname = "temps"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "temps.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -698,7 +699,7 @@ class Cmaps(object):
     @property
     def temps_r(self):
         cname = "temps_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "temps.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -708,7 +709,7 @@ class Cmaps(object):
     @property
     def tropic(self):
         cname = "tropic"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "tropic.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -718,7 +719,7 @@ class Cmaps(object):
     @property
     def tropic_r(self):
         cname = "tropic_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "tropic.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -728,7 +729,7 @@ class Cmaps(object):
     @property
     def vivid(self):
         cname = "vivid"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "vivid.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -738,7 +739,7 @@ class Cmaps(object):
     @property
     def vivid_r(self):
         cname = "vivid_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cartocolors",  "vivid.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -748,7 +749,7 @@ class Cmaps(object):
     @property
     def algae(self):
         cname = "algae"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "algae.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -758,7 +759,7 @@ class Cmaps(object):
     @property
     def algae_r(self):
         cname = "algae_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "algae.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -768,7 +769,7 @@ class Cmaps(object):
     @property
     def amp(self):
         cname = "amp"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "amp.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -778,7 +779,7 @@ class Cmaps(object):
     @property
     def amp_r(self):
         cname = "amp_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "amp.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -788,7 +789,7 @@ class Cmaps(object):
     @property
     def balance(self):
         cname = "balance"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "balance.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -798,7 +799,7 @@ class Cmaps(object):
     @property
     def balance_r(self):
         cname = "balance_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "balance.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -808,7 +809,7 @@ class Cmaps(object):
     @property
     def curl(self):
         cname = "curl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "curl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -818,7 +819,7 @@ class Cmaps(object):
     @property
     def curl_r(self):
         cname = "curl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "curl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -828,7 +829,7 @@ class Cmaps(object):
     @property
     def deep(self):
         cname = "deep"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "deep.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -838,7 +839,7 @@ class Cmaps(object):
     @property
     def deep_r(self):
         cname = "deep_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "deep.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -848,7 +849,7 @@ class Cmaps(object):
     @property
     def delta(self):
         cname = "delta"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "delta.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -858,7 +859,7 @@ class Cmaps(object):
     @property
     def delta_r(self):
         cname = "delta_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "delta.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -868,7 +869,7 @@ class Cmaps(object):
     @property
     def dense(self):
         cname = "dense"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "dense.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -878,7 +879,7 @@ class Cmaps(object):
     @property
     def dense_r(self):
         cname = "dense_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "dense.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -888,7 +889,7 @@ class Cmaps(object):
     @property
     def gray(self):
         cname = "gray"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -898,7 +899,7 @@ class Cmaps(object):
     @property
     def gray_r(self):
         cname = "gray_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -908,7 +909,7 @@ class Cmaps(object):
     @property
     def haline(self):
         cname = "haline"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "haline.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -918,7 +919,7 @@ class Cmaps(object):
     @property
     def haline_r(self):
         cname = "haline_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "haline.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -928,7 +929,7 @@ class Cmaps(object):
     @property
     def ice(self):
         cname = "ice"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "ice.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -938,7 +939,7 @@ class Cmaps(object):
     @property
     def ice_r(self):
         cname = "ice_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "ice.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -948,7 +949,7 @@ class Cmaps(object):
     @property
     def matter(self):
         cname = "matter"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "matter.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -958,7 +959,7 @@ class Cmaps(object):
     @property
     def matter_r(self):
         cname = "matter_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "matter.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -968,7 +969,7 @@ class Cmaps(object):
     @property
     def oxy(self):
         cname = "oxy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "oxy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -978,7 +979,7 @@ class Cmaps(object):
     @property
     def oxy_r(self):
         cname = "oxy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "oxy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -988,7 +989,7 @@ class Cmaps(object):
     @property
     def phase(self):
         cname = "phase"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "phase.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -998,7 +999,7 @@ class Cmaps(object):
     @property
     def phase_r(self):
         cname = "phase_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "phase.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1008,7 +1009,7 @@ class Cmaps(object):
     @property
     def solar(self):
         cname = "solar"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "solar.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1018,7 +1019,7 @@ class Cmaps(object):
     @property
     def solar_r(self):
         cname = "solar_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "solar.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1028,7 +1029,7 @@ class Cmaps(object):
     @property
     def speed(self):
         cname = "speed"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "speed.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1038,7 +1039,7 @@ class Cmaps(object):
     @property
     def speed_r(self):
         cname = "speed_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "speed.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1048,7 +1049,7 @@ class Cmaps(object):
     @property
     def tempo(self):
         cname = "tempo"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "tempo.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1058,7 +1059,7 @@ class Cmaps(object):
     @property
     def tempo_r(self):
         cname = "tempo_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "tempo.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1068,7 +1069,7 @@ class Cmaps(object):
     @property
     def thermal(self):
         cname = "thermal"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "thermal.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1078,7 +1079,7 @@ class Cmaps(object):
     @property
     def thermal_r(self):
         cname = "thermal_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "thermal.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1088,7 +1089,7 @@ class Cmaps(object):
     @property
     def turbid(self):
         cname = "turbid"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "turbid.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1098,7 +1099,7 @@ class Cmaps(object):
     @property
     def turbid_r(self):
         cname = "turbid_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cmocean",  "turbid.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1108,7 +1109,7 @@ class Cmaps(object):
     @property
     def accent(self):
         cname = "accent"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1118,7 +1119,7 @@ class Cmaps(object):
     @property
     def accent_r(self):
         cname = "accent_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1128,7 +1129,7 @@ class Cmaps(object):
     @property
     def accent_3(self):
         cname = "accent_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1138,7 +1139,7 @@ class Cmaps(object):
     @property
     def accent_3_r(self):
         cname = "accent_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1148,7 +1149,7 @@ class Cmaps(object):
     @property
     def accent_4(self):
         cname = "accent_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1158,7 +1159,7 @@ class Cmaps(object):
     @property
     def accent_4_r(self):
         cname = "accent_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1168,7 +1169,7 @@ class Cmaps(object):
     @property
     def accent_5(self):
         cname = "accent_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1178,7 +1179,7 @@ class Cmaps(object):
     @property
     def accent_5_r(self):
         cname = "accent_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1188,7 +1189,7 @@ class Cmaps(object):
     @property
     def accent_6(self):
         cname = "accent_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1198,7 +1199,7 @@ class Cmaps(object):
     @property
     def accent_6_r(self):
         cname = "accent_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1208,7 +1209,7 @@ class Cmaps(object):
     @property
     def accent_7(self):
         cname = "accent_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1218,7 +1219,7 @@ class Cmaps(object):
     @property
     def accent_7_r(self):
         cname = "accent_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1228,7 +1229,7 @@ class Cmaps(object):
     @property
     def accent_8(self):
         cname = "accent_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1238,7 +1239,7 @@ class Cmaps(object):
     @property
     def accent_8_r(self):
         cname = "accent_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "accent_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1248,7 +1249,7 @@ class Cmaps(object):
     @property
     def blues(self):
         cname = "blues"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1258,7 +1259,7 @@ class Cmaps(object):
     @property
     def blues_r(self):
         cname = "blues_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1268,7 +1269,7 @@ class Cmaps(object):
     @property
     def blues_3(self):
         cname = "blues_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1278,7 +1279,7 @@ class Cmaps(object):
     @property
     def blues_3_r(self):
         cname = "blues_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1288,7 +1289,7 @@ class Cmaps(object):
     @property
     def blues_4(self):
         cname = "blues_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1298,7 +1299,7 @@ class Cmaps(object):
     @property
     def blues_4_r(self):
         cname = "blues_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1308,7 +1309,7 @@ class Cmaps(object):
     @property
     def blues_5(self):
         cname = "blues_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1318,7 +1319,7 @@ class Cmaps(object):
     @property
     def blues_5_r(self):
         cname = "blues_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1328,7 +1329,7 @@ class Cmaps(object):
     @property
     def blues_6(self):
         cname = "blues_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1338,7 +1339,7 @@ class Cmaps(object):
     @property
     def blues_6_r(self):
         cname = "blues_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1348,7 +1349,7 @@ class Cmaps(object):
     @property
     def blues_7(self):
         cname = "blues_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1358,7 +1359,7 @@ class Cmaps(object):
     @property
     def blues_7_r(self):
         cname = "blues_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1368,7 +1369,7 @@ class Cmaps(object):
     @property
     def blues_8(self):
         cname = "blues_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1378,7 +1379,7 @@ class Cmaps(object):
     @property
     def blues_8_r(self):
         cname = "blues_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1388,7 +1389,7 @@ class Cmaps(object):
     @property
     def blues_9(self):
         cname = "blues_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1398,7 +1399,7 @@ class Cmaps(object):
     @property
     def blues_9_r(self):
         cname = "blues_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "blues_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1408,7 +1409,7 @@ class Cmaps(object):
     @property
     def brbg(self):
         cname = "brbg"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1418,7 +1419,7 @@ class Cmaps(object):
     @property
     def brbg_r(self):
         cname = "brbg_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1428,7 +1429,7 @@ class Cmaps(object):
     @property
     def brbg_10(self):
         cname = "brbg_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1438,7 +1439,7 @@ class Cmaps(object):
     @property
     def brbg_10_r(self):
         cname = "brbg_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1448,7 +1449,7 @@ class Cmaps(object):
     @property
     def brbg_11(self):
         cname = "brbg_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1458,7 +1459,7 @@ class Cmaps(object):
     @property
     def brbg_11_r(self):
         cname = "brbg_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1468,7 +1469,7 @@ class Cmaps(object):
     @property
     def brbg_3(self):
         cname = "brbg_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1478,7 +1479,7 @@ class Cmaps(object):
     @property
     def brbg_3_r(self):
         cname = "brbg_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1488,7 +1489,7 @@ class Cmaps(object):
     @property
     def brbg_4(self):
         cname = "brbg_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1498,7 +1499,7 @@ class Cmaps(object):
     @property
     def brbg_4_r(self):
         cname = "brbg_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1508,7 +1509,7 @@ class Cmaps(object):
     @property
     def brbg_5(self):
         cname = "brbg_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1518,7 +1519,7 @@ class Cmaps(object):
     @property
     def brbg_5_r(self):
         cname = "brbg_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1528,7 +1529,7 @@ class Cmaps(object):
     @property
     def brbg_6(self):
         cname = "brbg_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1538,7 +1539,7 @@ class Cmaps(object):
     @property
     def brbg_6_r(self):
         cname = "brbg_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1548,7 +1549,7 @@ class Cmaps(object):
     @property
     def brbg_7(self):
         cname = "brbg_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1558,7 +1559,7 @@ class Cmaps(object):
     @property
     def brbg_7_r(self):
         cname = "brbg_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1568,7 +1569,7 @@ class Cmaps(object):
     @property
     def brbg_8(self):
         cname = "brbg_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1578,7 +1579,7 @@ class Cmaps(object):
     @property
     def brbg_8_r(self):
         cname = "brbg_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1588,7 +1589,7 @@ class Cmaps(object):
     @property
     def brbg_9(self):
         cname = "brbg_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1598,7 +1599,7 @@ class Cmaps(object):
     @property
     def brbg_9_r(self):
         cname = "brbg_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "brbg_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1608,7 +1609,7 @@ class Cmaps(object):
     @property
     def bugn(self):
         cname = "bugn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1618,7 +1619,7 @@ class Cmaps(object):
     @property
     def bugn_r(self):
         cname = "bugn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1628,7 +1629,7 @@ class Cmaps(object):
     @property
     def bugn_3(self):
         cname = "bugn_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1638,7 +1639,7 @@ class Cmaps(object):
     @property
     def bugn_3_r(self):
         cname = "bugn_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1648,7 +1649,7 @@ class Cmaps(object):
     @property
     def bugn_4(self):
         cname = "bugn_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1658,7 +1659,7 @@ class Cmaps(object):
     @property
     def bugn_4_r(self):
         cname = "bugn_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1668,7 +1669,7 @@ class Cmaps(object):
     @property
     def bugn_5(self):
         cname = "bugn_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1678,7 +1679,7 @@ class Cmaps(object):
     @property
     def bugn_5_r(self):
         cname = "bugn_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1688,7 +1689,7 @@ class Cmaps(object):
     @property
     def bugn_6(self):
         cname = "bugn_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1698,7 +1699,7 @@ class Cmaps(object):
     @property
     def bugn_6_r(self):
         cname = "bugn_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1708,7 +1709,7 @@ class Cmaps(object):
     @property
     def bugn_7(self):
         cname = "bugn_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1718,7 +1719,7 @@ class Cmaps(object):
     @property
     def bugn_7_r(self):
         cname = "bugn_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1728,7 +1729,7 @@ class Cmaps(object):
     @property
     def bugn_8(self):
         cname = "bugn_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1738,7 +1739,7 @@ class Cmaps(object):
     @property
     def bugn_8_r(self):
         cname = "bugn_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1748,7 +1749,7 @@ class Cmaps(object):
     @property
     def bugn_9(self):
         cname = "bugn_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1758,7 +1759,7 @@ class Cmaps(object):
     @property
     def bugn_9_r(self):
         cname = "bugn_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bugn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1768,7 +1769,7 @@ class Cmaps(object):
     @property
     def bupu(self):
         cname = "bupu"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1778,7 +1779,7 @@ class Cmaps(object):
     @property
     def bupu_r(self):
         cname = "bupu_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1788,7 +1789,7 @@ class Cmaps(object):
     @property
     def bupu_3(self):
         cname = "bupu_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1798,7 +1799,7 @@ class Cmaps(object):
     @property
     def bupu_3_r(self):
         cname = "bupu_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1808,7 +1809,7 @@ class Cmaps(object):
     @property
     def bupu_4(self):
         cname = "bupu_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1818,7 +1819,7 @@ class Cmaps(object):
     @property
     def bupu_4_r(self):
         cname = "bupu_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1828,7 +1829,7 @@ class Cmaps(object):
     @property
     def bupu_5(self):
         cname = "bupu_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1838,7 +1839,7 @@ class Cmaps(object):
     @property
     def bupu_5_r(self):
         cname = "bupu_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1848,7 +1849,7 @@ class Cmaps(object):
     @property
     def bupu_6(self):
         cname = "bupu_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1858,7 +1859,7 @@ class Cmaps(object):
     @property
     def bupu_6_r(self):
         cname = "bupu_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1868,7 +1869,7 @@ class Cmaps(object):
     @property
     def bupu_7(self):
         cname = "bupu_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1878,7 +1879,7 @@ class Cmaps(object):
     @property
     def bupu_7_r(self):
         cname = "bupu_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1888,7 +1889,7 @@ class Cmaps(object):
     @property
     def bupu_8(self):
         cname = "bupu_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1898,7 +1899,7 @@ class Cmaps(object):
     @property
     def bupu_8_r(self):
         cname = "bupu_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1908,7 +1909,7 @@ class Cmaps(object):
     @property
     def bupu_9(self):
         cname = "bupu_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1918,7 +1919,7 @@ class Cmaps(object):
     @property
     def bupu_9_r(self):
         cname = "bupu_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "bupu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1928,7 +1929,7 @@ class Cmaps(object):
     @property
     def dark2(self):
         cname = "dark2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1938,7 +1939,7 @@ class Cmaps(object):
     @property
     def dark2_r(self):
         cname = "dark2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1948,7 +1949,7 @@ class Cmaps(object):
     @property
     def dark2_3(self):
         cname = "dark2_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1958,7 +1959,7 @@ class Cmaps(object):
     @property
     def dark2_3_r(self):
         cname = "dark2_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1968,7 +1969,7 @@ class Cmaps(object):
     @property
     def dark2_4(self):
         cname = "dark2_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1978,7 +1979,7 @@ class Cmaps(object):
     @property
     def dark2_4_r(self):
         cname = "dark2_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -1988,7 +1989,7 @@ class Cmaps(object):
     @property
     def dark2_5(self):
         cname = "dark2_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -1998,7 +1999,7 @@ class Cmaps(object):
     @property
     def dark2_5_r(self):
         cname = "dark2_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2008,7 +2009,7 @@ class Cmaps(object):
     @property
     def dark2_6(self):
         cname = "dark2_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2018,7 +2019,7 @@ class Cmaps(object):
     @property
     def dark2_6_r(self):
         cname = "dark2_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2028,7 +2029,7 @@ class Cmaps(object):
     @property
     def dark2_7(self):
         cname = "dark2_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2038,7 +2039,7 @@ class Cmaps(object):
     @property
     def dark2_7_r(self):
         cname = "dark2_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2048,7 +2049,7 @@ class Cmaps(object):
     @property
     def dark2_8(self):
         cname = "dark2_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2058,7 +2059,7 @@ class Cmaps(object):
     @property
     def dark2_8_r(self):
         cname = "dark2_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "dark2_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2068,7 +2069,7 @@ class Cmaps(object):
     @property
     def gnbu(self):
         cname = "gnbu"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2078,7 +2079,7 @@ class Cmaps(object):
     @property
     def gnbu_r(self):
         cname = "gnbu_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2088,7 +2089,7 @@ class Cmaps(object):
     @property
     def gnbu_3(self):
         cname = "gnbu_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2098,7 +2099,7 @@ class Cmaps(object):
     @property
     def gnbu_3_r(self):
         cname = "gnbu_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2108,7 +2109,7 @@ class Cmaps(object):
     @property
     def gnbu_4(self):
         cname = "gnbu_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2118,7 +2119,7 @@ class Cmaps(object):
     @property
     def gnbu_4_r(self):
         cname = "gnbu_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2128,7 +2129,7 @@ class Cmaps(object):
     @property
     def gnbu_5(self):
         cname = "gnbu_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2138,7 +2139,7 @@ class Cmaps(object):
     @property
     def gnbu_5_r(self):
         cname = "gnbu_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2148,7 +2149,7 @@ class Cmaps(object):
     @property
     def gnbu_6(self):
         cname = "gnbu_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2158,7 +2159,7 @@ class Cmaps(object):
     @property
     def gnbu_6_r(self):
         cname = "gnbu_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2168,7 +2169,7 @@ class Cmaps(object):
     @property
     def gnbu_7(self):
         cname = "gnbu_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2178,7 +2179,7 @@ class Cmaps(object):
     @property
     def gnbu_7_r(self):
         cname = "gnbu_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2188,7 +2189,7 @@ class Cmaps(object):
     @property
     def gnbu_8(self):
         cname = "gnbu_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2198,7 +2199,7 @@ class Cmaps(object):
     @property
     def gnbu_8_r(self):
         cname = "gnbu_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2208,7 +2209,7 @@ class Cmaps(object):
     @property
     def gnbu_9(self):
         cname = "gnbu_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2218,7 +2219,7 @@ class Cmaps(object):
     @property
     def gnbu_9_r(self):
         cname = "gnbu_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "gnbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2228,7 +2229,7 @@ class Cmaps(object):
     @property
     def greens(self):
         cname = "greens"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2238,7 +2239,7 @@ class Cmaps(object):
     @property
     def greens_r(self):
         cname = "greens_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2248,7 +2249,7 @@ class Cmaps(object):
     @property
     def greens_3(self):
         cname = "greens_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2258,7 +2259,7 @@ class Cmaps(object):
     @property
     def greens_3_r(self):
         cname = "greens_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2268,7 +2269,7 @@ class Cmaps(object):
     @property
     def greens_4(self):
         cname = "greens_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2278,7 +2279,7 @@ class Cmaps(object):
     @property
     def greens_4_r(self):
         cname = "greens_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2288,7 +2289,7 @@ class Cmaps(object):
     @property
     def greens_5(self):
         cname = "greens_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2298,7 +2299,7 @@ class Cmaps(object):
     @property
     def greens_5_r(self):
         cname = "greens_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2308,7 +2309,7 @@ class Cmaps(object):
     @property
     def greens_6(self):
         cname = "greens_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2318,7 +2319,7 @@ class Cmaps(object):
     @property
     def greens_6_r(self):
         cname = "greens_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2328,7 +2329,7 @@ class Cmaps(object):
     @property
     def greens_7(self):
         cname = "greens_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2338,7 +2339,7 @@ class Cmaps(object):
     @property
     def greens_7_r(self):
         cname = "greens_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2348,7 +2349,7 @@ class Cmaps(object):
     @property
     def greens_8(self):
         cname = "greens_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2358,7 +2359,7 @@ class Cmaps(object):
     @property
     def greens_8_r(self):
         cname = "greens_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2368,7 +2369,7 @@ class Cmaps(object):
     @property
     def greens_9(self):
         cname = "greens_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2378,7 +2379,7 @@ class Cmaps(object):
     @property
     def greens_9_r(self):
         cname = "greens_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greens_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2388,7 +2389,7 @@ class Cmaps(object):
     @property
     def greys(self):
         cname = "greys"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2398,7 +2399,7 @@ class Cmaps(object):
     @property
     def greys_r(self):
         cname = "greys_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2408,7 +2409,7 @@ class Cmaps(object):
     @property
     def greys_3(self):
         cname = "greys_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2418,7 +2419,7 @@ class Cmaps(object):
     @property
     def greys_3_r(self):
         cname = "greys_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2428,7 +2429,7 @@ class Cmaps(object):
     @property
     def greys_4(self):
         cname = "greys_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2438,7 +2439,7 @@ class Cmaps(object):
     @property
     def greys_4_r(self):
         cname = "greys_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2448,7 +2449,7 @@ class Cmaps(object):
     @property
     def greys_5(self):
         cname = "greys_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2458,7 +2459,7 @@ class Cmaps(object):
     @property
     def greys_5_r(self):
         cname = "greys_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2468,7 +2469,7 @@ class Cmaps(object):
     @property
     def greys_6(self):
         cname = "greys_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2478,7 +2479,7 @@ class Cmaps(object):
     @property
     def greys_6_r(self):
         cname = "greys_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2488,7 +2489,7 @@ class Cmaps(object):
     @property
     def greys_7(self):
         cname = "greys_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2498,7 +2499,7 @@ class Cmaps(object):
     @property
     def greys_7_r(self):
         cname = "greys_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2508,7 +2509,7 @@ class Cmaps(object):
     @property
     def greys_8(self):
         cname = "greys_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2518,7 +2519,7 @@ class Cmaps(object):
     @property
     def greys_8_r(self):
         cname = "greys_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2528,7 +2529,7 @@ class Cmaps(object):
     @property
     def greys_9(self):
         cname = "greys_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2538,7 +2539,7 @@ class Cmaps(object):
     @property
     def greys_9_r(self):
         cname = "greys_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "greys_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2548,7 +2549,7 @@ class Cmaps(object):
     @property
     def oranges(self):
         cname = "oranges"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2558,7 +2559,7 @@ class Cmaps(object):
     @property
     def oranges_r(self):
         cname = "oranges_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2568,7 +2569,7 @@ class Cmaps(object):
     @property
     def oranges_3(self):
         cname = "oranges_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2578,7 +2579,7 @@ class Cmaps(object):
     @property
     def oranges_3_r(self):
         cname = "oranges_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2588,7 +2589,7 @@ class Cmaps(object):
     @property
     def oranges_4(self):
         cname = "oranges_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2598,7 +2599,7 @@ class Cmaps(object):
     @property
     def oranges_4_r(self):
         cname = "oranges_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2608,7 +2609,7 @@ class Cmaps(object):
     @property
     def oranges_5(self):
         cname = "oranges_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2618,7 +2619,7 @@ class Cmaps(object):
     @property
     def oranges_5_r(self):
         cname = "oranges_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2628,7 +2629,7 @@ class Cmaps(object):
     @property
     def oranges_6(self):
         cname = "oranges_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2638,7 +2639,7 @@ class Cmaps(object):
     @property
     def oranges_6_r(self):
         cname = "oranges_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2648,7 +2649,7 @@ class Cmaps(object):
     @property
     def oranges_7(self):
         cname = "oranges_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2658,7 +2659,7 @@ class Cmaps(object):
     @property
     def oranges_7_r(self):
         cname = "oranges_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2668,7 +2669,7 @@ class Cmaps(object):
     @property
     def oranges_8(self):
         cname = "oranges_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2678,7 +2679,7 @@ class Cmaps(object):
     @property
     def oranges_8_r(self):
         cname = "oranges_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2688,7 +2689,7 @@ class Cmaps(object):
     @property
     def oranges_9(self):
         cname = "oranges_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2698,7 +2699,7 @@ class Cmaps(object):
     @property
     def oranges_9_r(self):
         cname = "oranges_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "oranges_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2708,7 +2709,7 @@ class Cmaps(object):
     @property
     def orrd(self):
         cname = "orrd"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2718,7 +2719,7 @@ class Cmaps(object):
     @property
     def orrd_r(self):
         cname = "orrd_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2728,7 +2729,7 @@ class Cmaps(object):
     @property
     def orrd_3(self):
         cname = "orrd_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2738,7 +2739,7 @@ class Cmaps(object):
     @property
     def orrd_3_r(self):
         cname = "orrd_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2748,7 +2749,7 @@ class Cmaps(object):
     @property
     def orrd_4(self):
         cname = "orrd_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2758,7 +2759,7 @@ class Cmaps(object):
     @property
     def orrd_4_r(self):
         cname = "orrd_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2768,7 +2769,7 @@ class Cmaps(object):
     @property
     def orrd_5(self):
         cname = "orrd_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2778,7 +2779,7 @@ class Cmaps(object):
     @property
     def orrd_5_r(self):
         cname = "orrd_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2788,7 +2789,7 @@ class Cmaps(object):
     @property
     def orrd_6(self):
         cname = "orrd_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2798,7 +2799,7 @@ class Cmaps(object):
     @property
     def orrd_6_r(self):
         cname = "orrd_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2808,7 +2809,7 @@ class Cmaps(object):
     @property
     def orrd_7(self):
         cname = "orrd_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2818,7 +2819,7 @@ class Cmaps(object):
     @property
     def orrd_7_r(self):
         cname = "orrd_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2828,7 +2829,7 @@ class Cmaps(object):
     @property
     def orrd_8(self):
         cname = "orrd_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2838,7 +2839,7 @@ class Cmaps(object):
     @property
     def orrd_8_r(self):
         cname = "orrd_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2848,7 +2849,7 @@ class Cmaps(object):
     @property
     def orrd_9(self):
         cname = "orrd_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2858,7 +2859,7 @@ class Cmaps(object):
     @property
     def orrd_9_r(self):
         cname = "orrd_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "orrd_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2868,7 +2869,7 @@ class Cmaps(object):
     @property
     def paired(self):
         cname = "paired"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2878,7 +2879,7 @@ class Cmaps(object):
     @property
     def paired_r(self):
         cname = "paired_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2888,7 +2889,7 @@ class Cmaps(object):
     @property
     def paired_10(self):
         cname = "paired_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2898,7 +2899,7 @@ class Cmaps(object):
     @property
     def paired_10_r(self):
         cname = "paired_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2908,7 +2909,7 @@ class Cmaps(object):
     @property
     def paired_11(self):
         cname = "paired_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2918,7 +2919,7 @@ class Cmaps(object):
     @property
     def paired_11_r(self):
         cname = "paired_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2928,7 +2929,7 @@ class Cmaps(object):
     @property
     def paired_12(self):
         cname = "paired_12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2938,7 +2939,7 @@ class Cmaps(object):
     @property
     def paired_12_r(self):
         cname = "paired_12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2948,7 +2949,7 @@ class Cmaps(object):
     @property
     def paired_3(self):
         cname = "paired_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2958,7 +2959,7 @@ class Cmaps(object):
     @property
     def paired_3_r(self):
         cname = "paired_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2968,7 +2969,7 @@ class Cmaps(object):
     @property
     def paired_4(self):
         cname = "paired_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2978,7 +2979,7 @@ class Cmaps(object):
     @property
     def paired_4_r(self):
         cname = "paired_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -2988,7 +2989,7 @@ class Cmaps(object):
     @property
     def paired_5(self):
         cname = "paired_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -2998,7 +2999,7 @@ class Cmaps(object):
     @property
     def paired_5_r(self):
         cname = "paired_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3008,7 +3009,7 @@ class Cmaps(object):
     @property
     def paired_6(self):
         cname = "paired_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3018,7 +3019,7 @@ class Cmaps(object):
     @property
     def paired_6_r(self):
         cname = "paired_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3028,7 +3029,7 @@ class Cmaps(object):
     @property
     def paired_7(self):
         cname = "paired_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3038,7 +3039,7 @@ class Cmaps(object):
     @property
     def paired_7_r(self):
         cname = "paired_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3048,7 +3049,7 @@ class Cmaps(object):
     @property
     def paired_8(self):
         cname = "paired_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3058,7 +3059,7 @@ class Cmaps(object):
     @property
     def paired_8_r(self):
         cname = "paired_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3068,7 +3069,7 @@ class Cmaps(object):
     @property
     def paired_9(self):
         cname = "paired_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3078,7 +3079,7 @@ class Cmaps(object):
     @property
     def paired_9_r(self):
         cname = "paired_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "paired_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3088,7 +3089,7 @@ class Cmaps(object):
     @property
     def pastel1(self):
         cname = "pastel1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3098,7 +3099,7 @@ class Cmaps(object):
     @property
     def pastel1_r(self):
         cname = "pastel1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3108,7 +3109,7 @@ class Cmaps(object):
     @property
     def pastel1_3(self):
         cname = "pastel1_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3118,7 +3119,7 @@ class Cmaps(object):
     @property
     def pastel1_3_r(self):
         cname = "pastel1_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3128,7 +3129,7 @@ class Cmaps(object):
     @property
     def pastel1_4(self):
         cname = "pastel1_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3138,7 +3139,7 @@ class Cmaps(object):
     @property
     def pastel1_4_r(self):
         cname = "pastel1_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3148,7 +3149,7 @@ class Cmaps(object):
     @property
     def pastel1_5(self):
         cname = "pastel1_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3158,7 +3159,7 @@ class Cmaps(object):
     @property
     def pastel1_5_r(self):
         cname = "pastel1_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3168,7 +3169,7 @@ class Cmaps(object):
     @property
     def pastel1_6(self):
         cname = "pastel1_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3178,7 +3179,7 @@ class Cmaps(object):
     @property
     def pastel1_6_r(self):
         cname = "pastel1_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3188,7 +3189,7 @@ class Cmaps(object):
     @property
     def pastel1_7(self):
         cname = "pastel1_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3198,7 +3199,7 @@ class Cmaps(object):
     @property
     def pastel1_7_r(self):
         cname = "pastel1_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3208,7 +3209,7 @@ class Cmaps(object):
     @property
     def pastel1_8(self):
         cname = "pastel1_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3218,7 +3219,7 @@ class Cmaps(object):
     @property
     def pastel1_8_r(self):
         cname = "pastel1_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3228,7 +3229,7 @@ class Cmaps(object):
     @property
     def pastel1_9(self):
         cname = "pastel1_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3238,7 +3239,7 @@ class Cmaps(object):
     @property
     def pastel1_9_r(self):
         cname = "pastel1_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel1_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3248,7 +3249,7 @@ class Cmaps(object):
     @property
     def pastel2(self):
         cname = "pastel2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3258,7 +3259,7 @@ class Cmaps(object):
     @property
     def pastel2_r(self):
         cname = "pastel2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3268,7 +3269,7 @@ class Cmaps(object):
     @property
     def pastel2_3(self):
         cname = "pastel2_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3278,7 +3279,7 @@ class Cmaps(object):
     @property
     def pastel2_3_r(self):
         cname = "pastel2_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3288,7 +3289,7 @@ class Cmaps(object):
     @property
     def pastel2_4(self):
         cname = "pastel2_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3298,7 +3299,7 @@ class Cmaps(object):
     @property
     def pastel2_4_r(self):
         cname = "pastel2_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3308,7 +3309,7 @@ class Cmaps(object):
     @property
     def pastel2_5(self):
         cname = "pastel2_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3318,7 +3319,7 @@ class Cmaps(object):
     @property
     def pastel2_5_r(self):
         cname = "pastel2_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3328,7 +3329,7 @@ class Cmaps(object):
     @property
     def pastel2_6(self):
         cname = "pastel2_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3338,7 +3339,7 @@ class Cmaps(object):
     @property
     def pastel2_6_r(self):
         cname = "pastel2_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3348,7 +3349,7 @@ class Cmaps(object):
     @property
     def pastel2_7(self):
         cname = "pastel2_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3358,7 +3359,7 @@ class Cmaps(object):
     @property
     def pastel2_7_r(self):
         cname = "pastel2_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3368,7 +3369,7 @@ class Cmaps(object):
     @property
     def pastel2_8(self):
         cname = "pastel2_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3378,7 +3379,7 @@ class Cmaps(object):
     @property
     def pastel2_8_r(self):
         cname = "pastel2_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pastel2_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3388,7 +3389,7 @@ class Cmaps(object):
     @property
     def piyg(self):
         cname = "piyg"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3398,7 +3399,7 @@ class Cmaps(object):
     @property
     def piyg_r(self):
         cname = "piyg_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3408,7 +3409,7 @@ class Cmaps(object):
     @property
     def piyg_10(self):
         cname = "piyg_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3418,7 +3419,7 @@ class Cmaps(object):
     @property
     def piyg_10_r(self):
         cname = "piyg_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3428,7 +3429,7 @@ class Cmaps(object):
     @property
     def piyg_11(self):
         cname = "piyg_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3438,7 +3439,7 @@ class Cmaps(object):
     @property
     def piyg_11_r(self):
         cname = "piyg_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3448,7 +3449,7 @@ class Cmaps(object):
     @property
     def piyg_3(self):
         cname = "piyg_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3458,7 +3459,7 @@ class Cmaps(object):
     @property
     def piyg_3_r(self):
         cname = "piyg_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3468,7 +3469,7 @@ class Cmaps(object):
     @property
     def piyg_4(self):
         cname = "piyg_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3478,7 +3479,7 @@ class Cmaps(object):
     @property
     def piyg_4_r(self):
         cname = "piyg_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3488,7 +3489,7 @@ class Cmaps(object):
     @property
     def piyg_5(self):
         cname = "piyg_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3498,7 +3499,7 @@ class Cmaps(object):
     @property
     def piyg_5_r(self):
         cname = "piyg_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3508,7 +3509,7 @@ class Cmaps(object):
     @property
     def piyg_6(self):
         cname = "piyg_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3518,7 +3519,7 @@ class Cmaps(object):
     @property
     def piyg_6_r(self):
         cname = "piyg_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3528,7 +3529,7 @@ class Cmaps(object):
     @property
     def piyg_7(self):
         cname = "piyg_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3538,7 +3539,7 @@ class Cmaps(object):
     @property
     def piyg_7_r(self):
         cname = "piyg_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3548,7 +3549,7 @@ class Cmaps(object):
     @property
     def piyg_8(self):
         cname = "piyg_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3558,7 +3559,7 @@ class Cmaps(object):
     @property
     def piyg_8_r(self):
         cname = "piyg_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3568,7 +3569,7 @@ class Cmaps(object):
     @property
     def piyg_9(self):
         cname = "piyg_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3578,7 +3579,7 @@ class Cmaps(object):
     @property
     def piyg_9_r(self):
         cname = "piyg_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "piyg_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3588,7 +3589,7 @@ class Cmaps(object):
     @property
     def prgn(self):
         cname = "prgn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3598,7 +3599,7 @@ class Cmaps(object):
     @property
     def prgn_r(self):
         cname = "prgn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3608,7 +3609,7 @@ class Cmaps(object):
     @property
     def prgn_10(self):
         cname = "prgn_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3618,7 +3619,7 @@ class Cmaps(object):
     @property
     def prgn_10_r(self):
         cname = "prgn_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3628,7 +3629,7 @@ class Cmaps(object):
     @property
     def prgn_11(self):
         cname = "prgn_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3638,7 +3639,7 @@ class Cmaps(object):
     @property
     def prgn_11_r(self):
         cname = "prgn_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3648,7 +3649,7 @@ class Cmaps(object):
     @property
     def prgn_3(self):
         cname = "prgn_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3658,7 +3659,7 @@ class Cmaps(object):
     @property
     def prgn_3_r(self):
         cname = "prgn_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3668,7 +3669,7 @@ class Cmaps(object):
     @property
     def prgn_4(self):
         cname = "prgn_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3678,7 +3679,7 @@ class Cmaps(object):
     @property
     def prgn_4_r(self):
         cname = "prgn_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3688,7 +3689,7 @@ class Cmaps(object):
     @property
     def prgn_5(self):
         cname = "prgn_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3698,7 +3699,7 @@ class Cmaps(object):
     @property
     def prgn_5_r(self):
         cname = "prgn_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3708,7 +3709,7 @@ class Cmaps(object):
     @property
     def prgn_6(self):
         cname = "prgn_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3718,7 +3719,7 @@ class Cmaps(object):
     @property
     def prgn_6_r(self):
         cname = "prgn_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3728,7 +3729,7 @@ class Cmaps(object):
     @property
     def prgn_7(self):
         cname = "prgn_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3738,7 +3739,7 @@ class Cmaps(object):
     @property
     def prgn_7_r(self):
         cname = "prgn_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3748,7 +3749,7 @@ class Cmaps(object):
     @property
     def prgn_8(self):
         cname = "prgn_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3758,7 +3759,7 @@ class Cmaps(object):
     @property
     def prgn_8_r(self):
         cname = "prgn_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3768,7 +3769,7 @@ class Cmaps(object):
     @property
     def prgn_9(self):
         cname = "prgn_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3778,7 +3779,7 @@ class Cmaps(object):
     @property
     def prgn_9_r(self):
         cname = "prgn_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "prgn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3788,7 +3789,7 @@ class Cmaps(object):
     @property
     def pubu(self):
         cname = "pubu"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3798,7 +3799,7 @@ class Cmaps(object):
     @property
     def pubu_r(self):
         cname = "pubu_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3808,7 +3809,7 @@ class Cmaps(object):
     @property
     def pubu_3(self):
         cname = "pubu_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3818,7 +3819,7 @@ class Cmaps(object):
     @property
     def pubu_3_r(self):
         cname = "pubu_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3828,7 +3829,7 @@ class Cmaps(object):
     @property
     def pubu_4(self):
         cname = "pubu_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3838,7 +3839,7 @@ class Cmaps(object):
     @property
     def pubu_4_r(self):
         cname = "pubu_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3848,7 +3849,7 @@ class Cmaps(object):
     @property
     def pubu_5(self):
         cname = "pubu_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3858,7 +3859,7 @@ class Cmaps(object):
     @property
     def pubu_5_r(self):
         cname = "pubu_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3868,7 +3869,7 @@ class Cmaps(object):
     @property
     def pubu_6(self):
         cname = "pubu_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3878,7 +3879,7 @@ class Cmaps(object):
     @property
     def pubu_6_r(self):
         cname = "pubu_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3888,7 +3889,7 @@ class Cmaps(object):
     @property
     def pubu_7(self):
         cname = "pubu_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3898,7 +3899,7 @@ class Cmaps(object):
     @property
     def pubu_7_r(self):
         cname = "pubu_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3908,7 +3909,7 @@ class Cmaps(object):
     @property
     def pubu_8(self):
         cname = "pubu_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3918,7 +3919,7 @@ class Cmaps(object):
     @property
     def pubu_8_r(self):
         cname = "pubu_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3928,7 +3929,7 @@ class Cmaps(object):
     @property
     def pubu_9(self):
         cname = "pubu_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3938,7 +3939,7 @@ class Cmaps(object):
     @property
     def pubu_9_r(self):
         cname = "pubu_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3948,7 +3949,7 @@ class Cmaps(object):
     @property
     def pubugn(self):
         cname = "pubugn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3958,7 +3959,7 @@ class Cmaps(object):
     @property
     def pubugn_r(self):
         cname = "pubugn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3968,7 +3969,7 @@ class Cmaps(object):
     @property
     def pubugn_3(self):
         cname = "pubugn_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3978,7 +3979,7 @@ class Cmaps(object):
     @property
     def pubugn_3_r(self):
         cname = "pubugn_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -3988,7 +3989,7 @@ class Cmaps(object):
     @property
     def pubugn_4(self):
         cname = "pubugn_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -3998,7 +3999,7 @@ class Cmaps(object):
     @property
     def pubugn_4_r(self):
         cname = "pubugn_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4008,7 +4009,7 @@ class Cmaps(object):
     @property
     def pubugn_5(self):
         cname = "pubugn_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4018,7 +4019,7 @@ class Cmaps(object):
     @property
     def pubugn_5_r(self):
         cname = "pubugn_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4028,7 +4029,7 @@ class Cmaps(object):
     @property
     def pubugn_6(self):
         cname = "pubugn_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4038,7 +4039,7 @@ class Cmaps(object):
     @property
     def pubugn_6_r(self):
         cname = "pubugn_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4048,7 +4049,7 @@ class Cmaps(object):
     @property
     def pubugn_7(self):
         cname = "pubugn_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4058,7 +4059,7 @@ class Cmaps(object):
     @property
     def pubugn_7_r(self):
         cname = "pubugn_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4068,7 +4069,7 @@ class Cmaps(object):
     @property
     def pubugn_8(self):
         cname = "pubugn_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4078,7 +4079,7 @@ class Cmaps(object):
     @property
     def pubugn_8_r(self):
         cname = "pubugn_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4088,7 +4089,7 @@ class Cmaps(object):
     @property
     def pubugn_9(self):
         cname = "pubugn_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4098,7 +4099,7 @@ class Cmaps(object):
     @property
     def pubugn_9_r(self):
         cname = "pubugn_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "pubugn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4108,7 +4109,7 @@ class Cmaps(object):
     @property
     def puor(self):
         cname = "puor"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4118,7 +4119,7 @@ class Cmaps(object):
     @property
     def puor_r(self):
         cname = "puor_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4128,7 +4129,7 @@ class Cmaps(object):
     @property
     def puor_10(self):
         cname = "puor_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4138,7 +4139,7 @@ class Cmaps(object):
     @property
     def puor_10_r(self):
         cname = "puor_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4148,7 +4149,7 @@ class Cmaps(object):
     @property
     def puor_11(self):
         cname = "puor_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4158,7 +4159,7 @@ class Cmaps(object):
     @property
     def puor_11_r(self):
         cname = "puor_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4168,7 +4169,7 @@ class Cmaps(object):
     @property
     def puor_3(self):
         cname = "puor_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4178,7 +4179,7 @@ class Cmaps(object):
     @property
     def puor_3_r(self):
         cname = "puor_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4188,7 +4189,7 @@ class Cmaps(object):
     @property
     def puor_4(self):
         cname = "puor_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4198,7 +4199,7 @@ class Cmaps(object):
     @property
     def puor_4_r(self):
         cname = "puor_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4208,7 +4209,7 @@ class Cmaps(object):
     @property
     def puor_5(self):
         cname = "puor_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4218,7 +4219,7 @@ class Cmaps(object):
     @property
     def puor_5_r(self):
         cname = "puor_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4228,7 +4229,7 @@ class Cmaps(object):
     @property
     def puor_6(self):
         cname = "puor_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4238,7 +4239,7 @@ class Cmaps(object):
     @property
     def puor_6_r(self):
         cname = "puor_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4248,7 +4249,7 @@ class Cmaps(object):
     @property
     def puor_7(self):
         cname = "puor_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4258,7 +4259,7 @@ class Cmaps(object):
     @property
     def puor_7_r(self):
         cname = "puor_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4268,7 +4269,7 @@ class Cmaps(object):
     @property
     def puor_8(self):
         cname = "puor_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4278,7 +4279,7 @@ class Cmaps(object):
     @property
     def puor_8_r(self):
         cname = "puor_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4288,7 +4289,7 @@ class Cmaps(object):
     @property
     def puor_9(self):
         cname = "puor_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4298,7 +4299,7 @@ class Cmaps(object):
     @property
     def puor_9_r(self):
         cname = "puor_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "puor_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4308,7 +4309,7 @@ class Cmaps(object):
     @property
     def purd(self):
         cname = "purd"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4318,7 +4319,7 @@ class Cmaps(object):
     @property
     def purd_r(self):
         cname = "purd_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4328,7 +4329,7 @@ class Cmaps(object):
     @property
     def purd_3(self):
         cname = "purd_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4338,7 +4339,7 @@ class Cmaps(object):
     @property
     def purd_3_r(self):
         cname = "purd_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4348,7 +4349,7 @@ class Cmaps(object):
     @property
     def purd_4(self):
         cname = "purd_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4358,7 +4359,7 @@ class Cmaps(object):
     @property
     def purd_4_r(self):
         cname = "purd_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4368,7 +4369,7 @@ class Cmaps(object):
     @property
     def purd_5(self):
         cname = "purd_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4378,7 +4379,7 @@ class Cmaps(object):
     @property
     def purd_5_r(self):
         cname = "purd_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4388,7 +4389,7 @@ class Cmaps(object):
     @property
     def purd_6(self):
         cname = "purd_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4398,7 +4399,7 @@ class Cmaps(object):
     @property
     def purd_6_r(self):
         cname = "purd_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4408,7 +4409,7 @@ class Cmaps(object):
     @property
     def purd_7(self):
         cname = "purd_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4418,7 +4419,7 @@ class Cmaps(object):
     @property
     def purd_7_r(self):
         cname = "purd_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4428,7 +4429,7 @@ class Cmaps(object):
     @property
     def purd_8(self):
         cname = "purd_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4438,7 +4439,7 @@ class Cmaps(object):
     @property
     def purd_8_r(self):
         cname = "purd_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4448,7 +4449,7 @@ class Cmaps(object):
     @property
     def purd_9(self):
         cname = "purd_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4458,7 +4459,7 @@ class Cmaps(object):
     @property
     def purd_9_r(self):
         cname = "purd_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purd_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4468,7 +4469,7 @@ class Cmaps(object):
     @property
     def purples(self):
         cname = "purples"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4478,7 +4479,7 @@ class Cmaps(object):
     @property
     def purples_r(self):
         cname = "purples_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4488,7 +4489,7 @@ class Cmaps(object):
     @property
     def purples_3(self):
         cname = "purples_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4498,7 +4499,7 @@ class Cmaps(object):
     @property
     def purples_3_r(self):
         cname = "purples_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4508,7 +4509,7 @@ class Cmaps(object):
     @property
     def purples_4(self):
         cname = "purples_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4518,7 +4519,7 @@ class Cmaps(object):
     @property
     def purples_4_r(self):
         cname = "purples_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4528,7 +4529,7 @@ class Cmaps(object):
     @property
     def purples_5(self):
         cname = "purples_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4538,7 +4539,7 @@ class Cmaps(object):
     @property
     def purples_5_r(self):
         cname = "purples_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4548,7 +4549,7 @@ class Cmaps(object):
     @property
     def purples_6(self):
         cname = "purples_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4558,7 +4559,7 @@ class Cmaps(object):
     @property
     def purples_6_r(self):
         cname = "purples_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4568,7 +4569,7 @@ class Cmaps(object):
     @property
     def purples_7(self):
         cname = "purples_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4578,7 +4579,7 @@ class Cmaps(object):
     @property
     def purples_7_r(self):
         cname = "purples_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4588,7 +4589,7 @@ class Cmaps(object):
     @property
     def purples_8(self):
         cname = "purples_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4598,7 +4599,7 @@ class Cmaps(object):
     @property
     def purples_8_r(self):
         cname = "purples_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4608,7 +4609,7 @@ class Cmaps(object):
     @property
     def purples_9(self):
         cname = "purples_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4618,7 +4619,7 @@ class Cmaps(object):
     @property
     def purples_9_r(self):
         cname = "purples_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "purples_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4628,7 +4629,7 @@ class Cmaps(object):
     @property
     def rdbu(self):
         cname = "rdbu"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4638,7 +4639,7 @@ class Cmaps(object):
     @property
     def rdbu_r(self):
         cname = "rdbu_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4648,7 +4649,7 @@ class Cmaps(object):
     @property
     def rdbu_10(self):
         cname = "rdbu_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4658,7 +4659,7 @@ class Cmaps(object):
     @property
     def rdbu_10_r(self):
         cname = "rdbu_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4668,7 +4669,7 @@ class Cmaps(object):
     @property
     def rdbu_11(self):
         cname = "rdbu_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4678,7 +4679,7 @@ class Cmaps(object):
     @property
     def rdbu_11_r(self):
         cname = "rdbu_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4688,7 +4689,7 @@ class Cmaps(object):
     @property
     def rdbu_3(self):
         cname = "rdbu_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4698,7 +4699,7 @@ class Cmaps(object):
     @property
     def rdbu_3_r(self):
         cname = "rdbu_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4708,7 +4709,7 @@ class Cmaps(object):
     @property
     def rdbu_4(self):
         cname = "rdbu_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4718,7 +4719,7 @@ class Cmaps(object):
     @property
     def rdbu_4_r(self):
         cname = "rdbu_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4728,7 +4729,7 @@ class Cmaps(object):
     @property
     def rdbu_5(self):
         cname = "rdbu_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4738,7 +4739,7 @@ class Cmaps(object):
     @property
     def rdbu_5_r(self):
         cname = "rdbu_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4748,7 +4749,7 @@ class Cmaps(object):
     @property
     def rdbu_6(self):
         cname = "rdbu_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4758,7 +4759,7 @@ class Cmaps(object):
     @property
     def rdbu_6_r(self):
         cname = "rdbu_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4768,7 +4769,7 @@ class Cmaps(object):
     @property
     def rdbu_7(self):
         cname = "rdbu_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4778,7 +4779,7 @@ class Cmaps(object):
     @property
     def rdbu_7_r(self):
         cname = "rdbu_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4788,7 +4789,7 @@ class Cmaps(object):
     @property
     def rdbu_8(self):
         cname = "rdbu_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4798,7 +4799,7 @@ class Cmaps(object):
     @property
     def rdbu_8_r(self):
         cname = "rdbu_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4808,7 +4809,7 @@ class Cmaps(object):
     @property
     def rdbu_9(self):
         cname = "rdbu_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4818,7 +4819,7 @@ class Cmaps(object):
     @property
     def rdbu_9_r(self):
         cname = "rdbu_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4828,7 +4829,7 @@ class Cmaps(object):
     @property
     def rdgy(self):
         cname = "rdgy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4838,7 +4839,7 @@ class Cmaps(object):
     @property
     def rdgy_r(self):
         cname = "rdgy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4848,7 +4849,7 @@ class Cmaps(object):
     @property
     def rdgy_10(self):
         cname = "rdgy_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4858,7 +4859,7 @@ class Cmaps(object):
     @property
     def rdgy_10_r(self):
         cname = "rdgy_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4868,7 +4869,7 @@ class Cmaps(object):
     @property
     def rdgy_11(self):
         cname = "rdgy_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4878,7 +4879,7 @@ class Cmaps(object):
     @property
     def rdgy_11_r(self):
         cname = "rdgy_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4888,7 +4889,7 @@ class Cmaps(object):
     @property
     def rdgy_3(self):
         cname = "rdgy_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4898,7 +4899,7 @@ class Cmaps(object):
     @property
     def rdgy_3_r(self):
         cname = "rdgy_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4908,7 +4909,7 @@ class Cmaps(object):
     @property
     def rdgy_4(self):
         cname = "rdgy_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4918,7 +4919,7 @@ class Cmaps(object):
     @property
     def rdgy_4_r(self):
         cname = "rdgy_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4928,7 +4929,7 @@ class Cmaps(object):
     @property
     def rdgy_5(self):
         cname = "rdgy_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4938,7 +4939,7 @@ class Cmaps(object):
     @property
     def rdgy_5_r(self):
         cname = "rdgy_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4948,7 +4949,7 @@ class Cmaps(object):
     @property
     def rdgy_6(self):
         cname = "rdgy_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4958,7 +4959,7 @@ class Cmaps(object):
     @property
     def rdgy_6_r(self):
         cname = "rdgy_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4968,7 +4969,7 @@ class Cmaps(object):
     @property
     def rdgy_7(self):
         cname = "rdgy_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4978,7 +4979,7 @@ class Cmaps(object):
     @property
     def rdgy_7_r(self):
         cname = "rdgy_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -4988,7 +4989,7 @@ class Cmaps(object):
     @property
     def rdgy_8(self):
         cname = "rdgy_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -4998,7 +4999,7 @@ class Cmaps(object):
     @property
     def rdgy_8_r(self):
         cname = "rdgy_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5008,7 +5009,7 @@ class Cmaps(object):
     @property
     def rdgy_9(self):
         cname = "rdgy_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5018,7 +5019,7 @@ class Cmaps(object):
     @property
     def rdgy_9_r(self):
         cname = "rdgy_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdgy_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5028,7 +5029,7 @@ class Cmaps(object):
     @property
     def rdpu(self):
         cname = "rdpu"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5038,7 +5039,7 @@ class Cmaps(object):
     @property
     def rdpu_r(self):
         cname = "rdpu_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5048,7 +5049,7 @@ class Cmaps(object):
     @property
     def rdpu_3(self):
         cname = "rdpu_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5058,7 +5059,7 @@ class Cmaps(object):
     @property
     def rdpu_3_r(self):
         cname = "rdpu_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5068,7 +5069,7 @@ class Cmaps(object):
     @property
     def rdpu_4(self):
         cname = "rdpu_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5078,7 +5079,7 @@ class Cmaps(object):
     @property
     def rdpu_4_r(self):
         cname = "rdpu_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5088,7 +5089,7 @@ class Cmaps(object):
     @property
     def rdpu_5(self):
         cname = "rdpu_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5098,7 +5099,7 @@ class Cmaps(object):
     @property
     def rdpu_5_r(self):
         cname = "rdpu_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5108,7 +5109,7 @@ class Cmaps(object):
     @property
     def rdpu_6(self):
         cname = "rdpu_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5118,7 +5119,7 @@ class Cmaps(object):
     @property
     def rdpu_6_r(self):
         cname = "rdpu_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5128,7 +5129,7 @@ class Cmaps(object):
     @property
     def rdpu_7(self):
         cname = "rdpu_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5138,7 +5139,7 @@ class Cmaps(object):
     @property
     def rdpu_7_r(self):
         cname = "rdpu_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5148,7 +5149,7 @@ class Cmaps(object):
     @property
     def rdpu_8(self):
         cname = "rdpu_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5158,7 +5159,7 @@ class Cmaps(object):
     @property
     def rdpu_8_r(self):
         cname = "rdpu_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5168,7 +5169,7 @@ class Cmaps(object):
     @property
     def rdpu_9(self):
         cname = "rdpu_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5178,7 +5179,7 @@ class Cmaps(object):
     @property
     def rdpu_9_r(self):
         cname = "rdpu_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdpu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5188,7 +5189,7 @@ class Cmaps(object):
     @property
     def rdylbu(self):
         cname = "rdylbu"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5198,7 +5199,7 @@ class Cmaps(object):
     @property
     def rdylbu_r(self):
         cname = "rdylbu_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5208,7 +5209,7 @@ class Cmaps(object):
     @property
     def rdylbu_10(self):
         cname = "rdylbu_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5218,7 +5219,7 @@ class Cmaps(object):
     @property
     def rdylbu_10_r(self):
         cname = "rdylbu_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5228,7 +5229,7 @@ class Cmaps(object):
     @property
     def rdylbu_11(self):
         cname = "rdylbu_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5238,7 +5239,7 @@ class Cmaps(object):
     @property
     def rdylbu_11_r(self):
         cname = "rdylbu_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5248,7 +5249,7 @@ class Cmaps(object):
     @property
     def rdylbu_3(self):
         cname = "rdylbu_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5258,7 +5259,7 @@ class Cmaps(object):
     @property
     def rdylbu_3_r(self):
         cname = "rdylbu_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5268,7 +5269,7 @@ class Cmaps(object):
     @property
     def rdylbu_4(self):
         cname = "rdylbu_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5278,7 +5279,7 @@ class Cmaps(object):
     @property
     def rdylbu_4_r(self):
         cname = "rdylbu_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5288,7 +5289,7 @@ class Cmaps(object):
     @property
     def rdylbu_5(self):
         cname = "rdylbu_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5298,7 +5299,7 @@ class Cmaps(object):
     @property
     def rdylbu_5_r(self):
         cname = "rdylbu_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5308,7 +5309,7 @@ class Cmaps(object):
     @property
     def rdylbu_6(self):
         cname = "rdylbu_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5318,7 +5319,7 @@ class Cmaps(object):
     @property
     def rdylbu_6_r(self):
         cname = "rdylbu_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5328,7 +5329,7 @@ class Cmaps(object):
     @property
     def rdylbu_7(self):
         cname = "rdylbu_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5338,7 +5339,7 @@ class Cmaps(object):
     @property
     def rdylbu_7_r(self):
         cname = "rdylbu_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5348,7 +5349,7 @@ class Cmaps(object):
     @property
     def rdylbu_8(self):
         cname = "rdylbu_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5358,7 +5359,7 @@ class Cmaps(object):
     @property
     def rdylbu_8_r(self):
         cname = "rdylbu_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5368,7 +5369,7 @@ class Cmaps(object):
     @property
     def rdylbu_9(self):
         cname = "rdylbu_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5378,7 +5379,7 @@ class Cmaps(object):
     @property
     def rdylbu_9_r(self):
         cname = "rdylbu_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5388,7 +5389,7 @@ class Cmaps(object):
     @property
     def rdylgn(self):
         cname = "rdylgn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5398,7 +5399,7 @@ class Cmaps(object):
     @property
     def rdylgn_r(self):
         cname = "rdylgn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5408,7 +5409,7 @@ class Cmaps(object):
     @property
     def rdylgn_10(self):
         cname = "rdylgn_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5418,7 +5419,7 @@ class Cmaps(object):
     @property
     def rdylgn_10_r(self):
         cname = "rdylgn_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5428,7 +5429,7 @@ class Cmaps(object):
     @property
     def rdylgn_11(self):
         cname = "rdylgn_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5438,7 +5439,7 @@ class Cmaps(object):
     @property
     def rdylgn_11_r(self):
         cname = "rdylgn_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5448,7 +5449,7 @@ class Cmaps(object):
     @property
     def rdylgn_3(self):
         cname = "rdylgn_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5458,7 +5459,7 @@ class Cmaps(object):
     @property
     def rdylgn_3_r(self):
         cname = "rdylgn_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5468,7 +5469,7 @@ class Cmaps(object):
     @property
     def rdylgn_4(self):
         cname = "rdylgn_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5478,7 +5479,7 @@ class Cmaps(object):
     @property
     def rdylgn_4_r(self):
         cname = "rdylgn_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5488,7 +5489,7 @@ class Cmaps(object):
     @property
     def rdylgn_5(self):
         cname = "rdylgn_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5498,7 +5499,7 @@ class Cmaps(object):
     @property
     def rdylgn_5_r(self):
         cname = "rdylgn_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5508,7 +5509,7 @@ class Cmaps(object):
     @property
     def rdylgn_6(self):
         cname = "rdylgn_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5518,7 +5519,7 @@ class Cmaps(object):
     @property
     def rdylgn_6_r(self):
         cname = "rdylgn_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5528,7 +5529,7 @@ class Cmaps(object):
     @property
     def rdylgn_7(self):
         cname = "rdylgn_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5538,7 +5539,7 @@ class Cmaps(object):
     @property
     def rdylgn_7_r(self):
         cname = "rdylgn_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5548,7 +5549,7 @@ class Cmaps(object):
     @property
     def rdylgn_8(self):
         cname = "rdylgn_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5558,7 +5559,7 @@ class Cmaps(object):
     @property
     def rdylgn_8_r(self):
         cname = "rdylgn_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5568,7 +5569,7 @@ class Cmaps(object):
     @property
     def rdylgn_9(self):
         cname = "rdylgn_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5578,7 +5579,7 @@ class Cmaps(object):
     @property
     def rdylgn_9_r(self):
         cname = "rdylgn_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "rdylgn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5588,7 +5589,7 @@ class Cmaps(object):
     @property
     def reds(self):
         cname = "reds"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5598,7 +5599,7 @@ class Cmaps(object):
     @property
     def reds_r(self):
         cname = "reds_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5608,7 +5609,7 @@ class Cmaps(object):
     @property
     def reds_3(self):
         cname = "reds_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5618,7 +5619,7 @@ class Cmaps(object):
     @property
     def reds_3_r(self):
         cname = "reds_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5628,7 +5629,7 @@ class Cmaps(object):
     @property
     def reds_4(self):
         cname = "reds_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5638,7 +5639,7 @@ class Cmaps(object):
     @property
     def reds_4_r(self):
         cname = "reds_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5648,7 +5649,7 @@ class Cmaps(object):
     @property
     def reds_5(self):
         cname = "reds_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5658,7 +5659,7 @@ class Cmaps(object):
     @property
     def reds_5_r(self):
         cname = "reds_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5668,7 +5669,7 @@ class Cmaps(object):
     @property
     def reds_6(self):
         cname = "reds_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5678,7 +5679,7 @@ class Cmaps(object):
     @property
     def reds_6_r(self):
         cname = "reds_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5688,7 +5689,7 @@ class Cmaps(object):
     @property
     def reds_7(self):
         cname = "reds_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5698,7 +5699,7 @@ class Cmaps(object):
     @property
     def reds_7_r(self):
         cname = "reds_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5708,7 +5709,7 @@ class Cmaps(object):
     @property
     def reds_8(self):
         cname = "reds_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5718,7 +5719,7 @@ class Cmaps(object):
     @property
     def reds_8_r(self):
         cname = "reds_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5728,7 +5729,7 @@ class Cmaps(object):
     @property
     def reds_9(self):
         cname = "reds_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5738,7 +5739,7 @@ class Cmaps(object):
     @property
     def reds_9_r(self):
         cname = "reds_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "reds_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5748,7 +5749,7 @@ class Cmaps(object):
     @property
     def set1(self):
         cname = "set1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5758,7 +5759,7 @@ class Cmaps(object):
     @property
     def set1_r(self):
         cname = "set1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5768,7 +5769,7 @@ class Cmaps(object):
     @property
     def set1_3(self):
         cname = "set1_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5778,7 +5779,7 @@ class Cmaps(object):
     @property
     def set1_3_r(self):
         cname = "set1_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5788,7 +5789,7 @@ class Cmaps(object):
     @property
     def set1_4(self):
         cname = "set1_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5798,7 +5799,7 @@ class Cmaps(object):
     @property
     def set1_4_r(self):
         cname = "set1_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5808,7 +5809,7 @@ class Cmaps(object):
     @property
     def set1_5(self):
         cname = "set1_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5818,7 +5819,7 @@ class Cmaps(object):
     @property
     def set1_5_r(self):
         cname = "set1_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5828,7 +5829,7 @@ class Cmaps(object):
     @property
     def set1_6(self):
         cname = "set1_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5838,7 +5839,7 @@ class Cmaps(object):
     @property
     def set1_6_r(self):
         cname = "set1_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5848,7 +5849,7 @@ class Cmaps(object):
     @property
     def set1_7(self):
         cname = "set1_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5858,7 +5859,7 @@ class Cmaps(object):
     @property
     def set1_7_r(self):
         cname = "set1_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5868,7 +5869,7 @@ class Cmaps(object):
     @property
     def set1_8(self):
         cname = "set1_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5878,7 +5879,7 @@ class Cmaps(object):
     @property
     def set1_8_r(self):
         cname = "set1_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5888,7 +5889,7 @@ class Cmaps(object):
     @property
     def set1_9(self):
         cname = "set1_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5898,7 +5899,7 @@ class Cmaps(object):
     @property
     def set1_9_r(self):
         cname = "set1_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set1_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5908,7 +5909,7 @@ class Cmaps(object):
     @property
     def set2(self):
         cname = "set2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5918,7 +5919,7 @@ class Cmaps(object):
     @property
     def set2_r(self):
         cname = "set2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5928,7 +5929,7 @@ class Cmaps(object):
     @property
     def set2_3(self):
         cname = "set2_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5938,7 +5939,7 @@ class Cmaps(object):
     @property
     def set2_3_r(self):
         cname = "set2_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5948,7 +5949,7 @@ class Cmaps(object):
     @property
     def set2_4(self):
         cname = "set2_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5958,7 +5959,7 @@ class Cmaps(object):
     @property
     def set2_4_r(self):
         cname = "set2_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5968,7 +5969,7 @@ class Cmaps(object):
     @property
     def set2_5(self):
         cname = "set2_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5978,7 +5979,7 @@ class Cmaps(object):
     @property
     def set2_5_r(self):
         cname = "set2_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -5988,7 +5989,7 @@ class Cmaps(object):
     @property
     def set2_6(self):
         cname = "set2_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -5998,7 +5999,7 @@ class Cmaps(object):
     @property
     def set2_6_r(self):
         cname = "set2_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6008,7 +6009,7 @@ class Cmaps(object):
     @property
     def set2_7(self):
         cname = "set2_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6018,7 +6019,7 @@ class Cmaps(object):
     @property
     def set2_7_r(self):
         cname = "set2_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6028,7 +6029,7 @@ class Cmaps(object):
     @property
     def set2_8(self):
         cname = "set2_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6038,7 +6039,7 @@ class Cmaps(object):
     @property
     def set2_8_r(self):
         cname = "set2_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set2_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6048,7 +6049,7 @@ class Cmaps(object):
     @property
     def set3(self):
         cname = "set3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6058,7 +6059,7 @@ class Cmaps(object):
     @property
     def set3_r(self):
         cname = "set3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6068,7 +6069,7 @@ class Cmaps(object):
     @property
     def set3_10(self):
         cname = "set3_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6078,7 +6079,7 @@ class Cmaps(object):
     @property
     def set3_10_r(self):
         cname = "set3_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6088,7 +6089,7 @@ class Cmaps(object):
     @property
     def set3_11(self):
         cname = "set3_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6098,7 +6099,7 @@ class Cmaps(object):
     @property
     def set3_11_r(self):
         cname = "set3_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6108,7 +6109,7 @@ class Cmaps(object):
     @property
     def set3_12(self):
         cname = "set3_12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6118,7 +6119,7 @@ class Cmaps(object):
     @property
     def set3_12_r(self):
         cname = "set3_12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6128,7 +6129,7 @@ class Cmaps(object):
     @property
     def set3_3(self):
         cname = "set3_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6138,7 +6139,7 @@ class Cmaps(object):
     @property
     def set3_3_r(self):
         cname = "set3_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6148,7 +6149,7 @@ class Cmaps(object):
     @property
     def set3_4(self):
         cname = "set3_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6158,7 +6159,7 @@ class Cmaps(object):
     @property
     def set3_4_r(self):
         cname = "set3_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6168,7 +6169,7 @@ class Cmaps(object):
     @property
     def set3_5(self):
         cname = "set3_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6178,7 +6179,7 @@ class Cmaps(object):
     @property
     def set3_5_r(self):
         cname = "set3_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6188,7 +6189,7 @@ class Cmaps(object):
     @property
     def set3_6(self):
         cname = "set3_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6198,7 +6199,7 @@ class Cmaps(object):
     @property
     def set3_6_r(self):
         cname = "set3_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6208,7 +6209,7 @@ class Cmaps(object):
     @property
     def set3_7(self):
         cname = "set3_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6218,7 +6219,7 @@ class Cmaps(object):
     @property
     def set3_7_r(self):
         cname = "set3_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6228,7 +6229,7 @@ class Cmaps(object):
     @property
     def set3_8(self):
         cname = "set3_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6238,7 +6239,7 @@ class Cmaps(object):
     @property
     def set3_8_r(self):
         cname = "set3_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6248,7 +6249,7 @@ class Cmaps(object):
     @property
     def set3_9(self):
         cname = "set3_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6258,7 +6259,7 @@ class Cmaps(object):
     @property
     def set3_9_r(self):
         cname = "set3_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "set3_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6268,7 +6269,7 @@ class Cmaps(object):
     @property
     def spectral(self):
         cname = "spectral"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6278,7 +6279,7 @@ class Cmaps(object):
     @property
     def spectral_r(self):
         cname = "spectral_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6288,7 +6289,7 @@ class Cmaps(object):
     @property
     def spectral_10(self):
         cname = "spectral_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6298,7 +6299,7 @@ class Cmaps(object):
     @property
     def spectral_10_r(self):
         cname = "spectral_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6308,7 +6309,7 @@ class Cmaps(object):
     @property
     def spectral_11(self):
         cname = "spectral_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6318,7 +6319,7 @@ class Cmaps(object):
     @property
     def spectral_11_r(self):
         cname = "spectral_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6328,7 +6329,7 @@ class Cmaps(object):
     @property
     def spectral_3(self):
         cname = "spectral_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6338,7 +6339,7 @@ class Cmaps(object):
     @property
     def spectral_3_r(self):
         cname = "spectral_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6348,7 +6349,7 @@ class Cmaps(object):
     @property
     def spectral_4(self):
         cname = "spectral_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6358,7 +6359,7 @@ class Cmaps(object):
     @property
     def spectral_4_r(self):
         cname = "spectral_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6368,7 +6369,7 @@ class Cmaps(object):
     @property
     def spectral_5(self):
         cname = "spectral_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6378,7 +6379,7 @@ class Cmaps(object):
     @property
     def spectral_5_r(self):
         cname = "spectral_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6388,7 +6389,7 @@ class Cmaps(object):
     @property
     def spectral_6(self):
         cname = "spectral_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6398,7 +6399,7 @@ class Cmaps(object):
     @property
     def spectral_6_r(self):
         cname = "spectral_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6408,7 +6409,7 @@ class Cmaps(object):
     @property
     def spectral_7(self):
         cname = "spectral_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6418,7 +6419,7 @@ class Cmaps(object):
     @property
     def spectral_7_r(self):
         cname = "spectral_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6428,7 +6429,7 @@ class Cmaps(object):
     @property
     def spectral_8(self):
         cname = "spectral_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6438,7 +6439,7 @@ class Cmaps(object):
     @property
     def spectral_8_r(self):
         cname = "spectral_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6448,7 +6449,7 @@ class Cmaps(object):
     @property
     def spectral_9(self):
         cname = "spectral_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6458,7 +6459,7 @@ class Cmaps(object):
     @property
     def spectral_9_r(self):
         cname = "spectral_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "spectral_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6468,7 +6469,7 @@ class Cmaps(object):
     @property
     def ylgn(self):
         cname = "ylgn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6478,7 +6479,7 @@ class Cmaps(object):
     @property
     def ylgn_r(self):
         cname = "ylgn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6488,7 +6489,7 @@ class Cmaps(object):
     @property
     def ylgn_3(self):
         cname = "ylgn_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6498,7 +6499,7 @@ class Cmaps(object):
     @property
     def ylgn_3_r(self):
         cname = "ylgn_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6508,7 +6509,7 @@ class Cmaps(object):
     @property
     def ylgn_4(self):
         cname = "ylgn_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6518,7 +6519,7 @@ class Cmaps(object):
     @property
     def ylgn_4_r(self):
         cname = "ylgn_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6528,7 +6529,7 @@ class Cmaps(object):
     @property
     def ylgn_5(self):
         cname = "ylgn_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6538,7 +6539,7 @@ class Cmaps(object):
     @property
     def ylgn_5_r(self):
         cname = "ylgn_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6548,7 +6549,7 @@ class Cmaps(object):
     @property
     def ylgn_6(self):
         cname = "ylgn_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6558,7 +6559,7 @@ class Cmaps(object):
     @property
     def ylgn_6_r(self):
         cname = "ylgn_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6568,7 +6569,7 @@ class Cmaps(object):
     @property
     def ylgn_7(self):
         cname = "ylgn_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6578,7 +6579,7 @@ class Cmaps(object):
     @property
     def ylgn_7_r(self):
         cname = "ylgn_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6588,7 +6589,7 @@ class Cmaps(object):
     @property
     def ylgn_8(self):
         cname = "ylgn_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6598,7 +6599,7 @@ class Cmaps(object):
     @property
     def ylgn_8_r(self):
         cname = "ylgn_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6608,7 +6609,7 @@ class Cmaps(object):
     @property
     def ylgn_9(self):
         cname = "ylgn_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6618,7 +6619,7 @@ class Cmaps(object):
     @property
     def ylgn_9_r(self):
         cname = "ylgn_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgn_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6628,7 +6629,7 @@ class Cmaps(object):
     @property
     def ylgnbu(self):
         cname = "ylgnbu"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6638,7 +6639,7 @@ class Cmaps(object):
     @property
     def ylgnbu_r(self):
         cname = "ylgnbu_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6648,7 +6649,7 @@ class Cmaps(object):
     @property
     def ylgnbu_3(self):
         cname = "ylgnbu_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6658,7 +6659,7 @@ class Cmaps(object):
     @property
     def ylgnbu_3_r(self):
         cname = "ylgnbu_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6668,7 +6669,7 @@ class Cmaps(object):
     @property
     def ylgnbu_4(self):
         cname = "ylgnbu_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6678,7 +6679,7 @@ class Cmaps(object):
     @property
     def ylgnbu_4_r(self):
         cname = "ylgnbu_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6688,7 +6689,7 @@ class Cmaps(object):
     @property
     def ylgnbu_5(self):
         cname = "ylgnbu_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6698,7 +6699,7 @@ class Cmaps(object):
     @property
     def ylgnbu_5_r(self):
         cname = "ylgnbu_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6708,7 +6709,7 @@ class Cmaps(object):
     @property
     def ylgnbu_6(self):
         cname = "ylgnbu_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6718,7 +6719,7 @@ class Cmaps(object):
     @property
     def ylgnbu_6_r(self):
         cname = "ylgnbu_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6728,7 +6729,7 @@ class Cmaps(object):
     @property
     def ylgnbu_7(self):
         cname = "ylgnbu_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6738,7 +6739,7 @@ class Cmaps(object):
     @property
     def ylgnbu_7_r(self):
         cname = "ylgnbu_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6748,7 +6749,7 @@ class Cmaps(object):
     @property
     def ylgnbu_8(self):
         cname = "ylgnbu_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6758,7 +6759,7 @@ class Cmaps(object):
     @property
     def ylgnbu_8_r(self):
         cname = "ylgnbu_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6768,7 +6769,7 @@ class Cmaps(object):
     @property
     def ylgnbu_9(self):
         cname = "ylgnbu_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6778,7 +6779,7 @@ class Cmaps(object):
     @property
     def ylgnbu_9_r(self):
         cname = "ylgnbu_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylgnbu_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6788,7 +6789,7 @@ class Cmaps(object):
     @property
     def ylorbr(self):
         cname = "ylorbr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6798,7 +6799,7 @@ class Cmaps(object):
     @property
     def ylorbr_r(self):
         cname = "ylorbr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6808,7 +6809,7 @@ class Cmaps(object):
     @property
     def ylorbr_3(self):
         cname = "ylorbr_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6818,7 +6819,7 @@ class Cmaps(object):
     @property
     def ylorbr_3_r(self):
         cname = "ylorbr_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6828,7 +6829,7 @@ class Cmaps(object):
     @property
     def ylorbr_4(self):
         cname = "ylorbr_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6838,7 +6839,7 @@ class Cmaps(object):
     @property
     def ylorbr_4_r(self):
         cname = "ylorbr_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6848,7 +6849,7 @@ class Cmaps(object):
     @property
     def ylorbr_5(self):
         cname = "ylorbr_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6858,7 +6859,7 @@ class Cmaps(object):
     @property
     def ylorbr_5_r(self):
         cname = "ylorbr_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6868,7 +6869,7 @@ class Cmaps(object):
     @property
     def ylorbr_6(self):
         cname = "ylorbr_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6878,7 +6879,7 @@ class Cmaps(object):
     @property
     def ylorbr_6_r(self):
         cname = "ylorbr_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6888,7 +6889,7 @@ class Cmaps(object):
     @property
     def ylorbr_7(self):
         cname = "ylorbr_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6898,7 +6899,7 @@ class Cmaps(object):
     @property
     def ylorbr_7_r(self):
         cname = "ylorbr_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6908,7 +6909,7 @@ class Cmaps(object):
     @property
     def ylorbr_8(self):
         cname = "ylorbr_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6918,7 +6919,7 @@ class Cmaps(object):
     @property
     def ylorbr_8_r(self):
         cname = "ylorbr_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6928,7 +6929,7 @@ class Cmaps(object):
     @property
     def ylorbr_9(self):
         cname = "ylorbr_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6938,7 +6939,7 @@ class Cmaps(object):
     @property
     def ylorbr_9_r(self):
         cname = "ylorbr_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorbr_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6948,7 +6949,7 @@ class Cmaps(object):
     @property
     def ylorrd(self):
         cname = "ylorrd"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6958,7 +6959,7 @@ class Cmaps(object):
     @property
     def ylorrd_r(self):
         cname = "ylorrd_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6968,7 +6969,7 @@ class Cmaps(object):
     @property
     def ylorrd_3(self):
         cname = "ylorrd_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6978,7 +6979,7 @@ class Cmaps(object):
     @property
     def ylorrd_3_r(self):
         cname = "ylorrd_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -6988,7 +6989,7 @@ class Cmaps(object):
     @property
     def ylorrd_4(self):
         cname = "ylorrd_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -6998,7 +6999,7 @@ class Cmaps(object):
     @property
     def ylorrd_4_r(self):
         cname = "ylorrd_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7008,7 +7009,7 @@ class Cmaps(object):
     @property
     def ylorrd_5(self):
         cname = "ylorrd_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7018,7 +7019,7 @@ class Cmaps(object):
     @property
     def ylorrd_5_r(self):
         cname = "ylorrd_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7028,7 +7029,7 @@ class Cmaps(object):
     @property
     def ylorrd_6(self):
         cname = "ylorrd_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7038,7 +7039,7 @@ class Cmaps(object):
     @property
     def ylorrd_6_r(self):
         cname = "ylorrd_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7048,7 +7049,7 @@ class Cmaps(object):
     @property
     def ylorrd_7(self):
         cname = "ylorrd_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7058,7 +7059,7 @@ class Cmaps(object):
     @property
     def ylorrd_7_r(self):
         cname = "ylorrd_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7068,7 +7069,7 @@ class Cmaps(object):
     @property
     def ylorrd_8(self):
         cname = "ylorrd_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7078,7 +7079,7 @@ class Cmaps(object):
     @property
     def ylorrd_8_r(self):
         cname = "ylorrd_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7088,7 +7089,7 @@ class Cmaps(object):
     @property
     def ylorrd_9(self):
         cname = "ylorrd_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7098,7 +7099,7 @@ class Cmaps(object):
     @property
     def ylorrd_9_r(self):
         cname = "ylorrd_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorbrewer",  "ylorrd_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7108,7 +7109,7 @@ class Cmaps(object):
     @property
     def classic_16(self):
         cname = "classic_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "classic_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7118,7 +7119,7 @@ class Cmaps(object):
     @property
     def classic_16_r(self):
         cname = "classic_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "classic_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7128,7 +7129,7 @@ class Cmaps(object):
     @property
     def cubehelix1_16(self):
         cname = "cubehelix1_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "cubehelix1_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7138,7 +7139,7 @@ class Cmaps(object):
     @property
     def cubehelix1_16_r(self):
         cname = "cubehelix1_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "cubehelix1_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7148,7 +7149,7 @@ class Cmaps(object):
     @property
     def cubehelix2_16(self):
         cname = "cubehelix2_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "cubehelix2_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7158,7 +7159,7 @@ class Cmaps(object):
     @property
     def cubehelix2_16_r(self):
         cname = "cubehelix2_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "cubehelix2_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7168,7 +7169,7 @@ class Cmaps(object):
     @property
     def cubehelix3_16(self):
         cname = "cubehelix3_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "cubehelix3_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7178,7 +7179,7 @@ class Cmaps(object):
     @property
     def cubehelix3_16_r(self):
         cname = "cubehelix3_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "cubehelix3_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7188,7 +7189,7 @@ class Cmaps(object):
     @property
     def jim_special_16(self):
         cname = "jim_special_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "jim_special_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7198,7 +7199,7 @@ class Cmaps(object):
     @property
     def jim_special_16_r(self):
         cname = "jim_special_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "jim_special_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7208,7 +7209,7 @@ class Cmaps(object):
     @property
     def perceptual_rainbow_16(self):
         cname = "perceptual_rainbow_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "perceptual_rainbow_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7218,7 +7219,7 @@ class Cmaps(object):
     @property
     def perceptual_rainbow_16_r(self):
         cname = "perceptual_rainbow_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "perceptual_rainbow_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7228,7 +7229,7 @@ class Cmaps(object):
     @property
     def purple_16(self):
         cname = "purple_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "purple_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7238,7 +7239,7 @@ class Cmaps(object):
     @property
     def purple_16_r(self):
         cname = "purple_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "purple_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7248,7 +7249,7 @@ class Cmaps(object):
     @property
     def red_16(self):
         cname = "red_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "red_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7258,7 +7259,7 @@ class Cmaps(object):
     @property
     def red_16_r(self):
         cname = "red_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "cubehelix",  "red_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7268,7 +7269,7 @@ class Cmaps(object):
     @property
     def BkBlAqGrYeOrReViWh200(self):
         cname = "BkBlAqGrYeOrReViWh200"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BkBlAqGrYeOrReViWh200.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7278,7 +7279,7 @@ class Cmaps(object):
     @property
     def BkBlAqGrYeOrReViWh200_r(self):
         cname = "BkBlAqGrYeOrReViWh200_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BkBlAqGrYeOrReViWh200.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7288,7 +7289,7 @@ class Cmaps(object):
     @property
     def BlAqGrWh2YeOrReVi22(self):
         cname = "BlAqGrWh2YeOrReVi22"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlAqGrWh2YeOrReVi22.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7298,7 +7299,7 @@ class Cmaps(object):
     @property
     def BlAqGrWh2YeOrReVi22_r(self):
         cname = "BlAqGrWh2YeOrReVi22_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlAqGrWh2YeOrReVi22.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7308,7 +7309,7 @@ class Cmaps(object):
     @property
     def BlAqGrYeOrRe(self):
         cname = "BlAqGrYeOrRe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlAqGrYeOrRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7318,7 +7319,7 @@ class Cmaps(object):
     @property
     def BlAqGrYeOrRe_r(self):
         cname = "BlAqGrYeOrRe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlAqGrYeOrRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7328,7 +7329,7 @@ class Cmaps(object):
     @property
     def BlAqGrYeOrReVi200(self):
         cname = "BlAqGrYeOrReVi200"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlAqGrYeOrReVi200.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7338,7 +7339,7 @@ class Cmaps(object):
     @property
     def BlAqGrYeOrReVi200_r(self):
         cname = "BlAqGrYeOrReVi200_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlAqGrYeOrReVi200.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7348,7 +7349,7 @@ class Cmaps(object):
     @property
     def BlGrYeOrReVi200(self):
         cname = "BlGrYeOrReVi200"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlGrYeOrReVi200.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7358,7 +7359,7 @@ class Cmaps(object):
     @property
     def BlGrYeOrReVi200_r(self):
         cname = "BlGrYeOrReVi200_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlGrYeOrReVi200.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7368,7 +7369,7 @@ class Cmaps(object):
     @property
     def BlRe(self):
         cname = "BlRe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7378,7 +7379,7 @@ class Cmaps(object):
     @property
     def BlRe_r(self):
         cname = "BlRe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7388,7 +7389,7 @@ class Cmaps(object):
     @property
     def BlWhRe(self):
         cname = "BlWhRe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlWhRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7398,7 +7399,7 @@ class Cmaps(object):
     @property
     def BlWhRe_r(self):
         cname = "BlWhRe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlWhRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7408,7 +7409,7 @@ class Cmaps(object):
     @property
     def BlueDarkOrange18(self):
         cname = "BlueDarkOrange18"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueDarkOrange18.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7418,7 +7419,7 @@ class Cmaps(object):
     @property
     def BlueDarkOrange18_r(self):
         cname = "BlueDarkOrange18_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueDarkOrange18.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7428,7 +7429,7 @@ class Cmaps(object):
     @property
     def BlueDarkRed18(self):
         cname = "BlueDarkRed18"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueDarkRed18.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7438,7 +7439,7 @@ class Cmaps(object):
     @property
     def BlueDarkRed18_r(self):
         cname = "BlueDarkRed18_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueDarkRed18.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7448,7 +7449,7 @@ class Cmaps(object):
     @property
     def BlueGreen14(self):
         cname = "BlueGreen14"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueGreen14.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7458,7 +7459,7 @@ class Cmaps(object):
     @property
     def BlueGreen14_r(self):
         cname = "BlueGreen14_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueGreen14.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7468,7 +7469,7 @@ class Cmaps(object):
     @property
     def BlueRed(self):
         cname = "BlueRed"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7478,7 +7479,7 @@ class Cmaps(object):
     @property
     def BlueRed_r(self):
         cname = "BlueRed_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7488,7 +7489,7 @@ class Cmaps(object):
     @property
     def BlueRedGray(self):
         cname = "BlueRedGray"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueRedGray.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7498,7 +7499,7 @@ class Cmaps(object):
     @property
     def BlueRedGray_r(self):
         cname = "BlueRedGray_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueRedGray.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7508,7 +7509,7 @@ class Cmaps(object):
     @property
     def BlueWhiteOrangeRed(self):
         cname = "BlueWhiteOrangeRed"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueWhiteOrangeRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7518,7 +7519,7 @@ class Cmaps(object):
     @property
     def BlueWhiteOrangeRed_r(self):
         cname = "BlueWhiteOrangeRed_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueWhiteOrangeRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7528,7 +7529,7 @@ class Cmaps(object):
     @property
     def BlueYellowRed(self):
         cname = "BlueYellowRed"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueYellowRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7538,7 +7539,7 @@ class Cmaps(object):
     @property
     def BlueYellowRed_r(self):
         cname = "BlueYellowRed_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BlueYellowRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7548,7 +7549,7 @@ class Cmaps(object):
     @property
     def BrownBlue12(self):
         cname = "BrownBlue12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BrownBlue12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7558,7 +7559,7 @@ class Cmaps(object):
     @property
     def BrownBlue12_r(self):
         cname = "BrownBlue12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "BrownBlue12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7568,7 +7569,7 @@ class Cmaps(object):
     @property
     def Cat12(self):
         cname = "Cat12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "Cat12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7578,7 +7579,7 @@ class Cmaps(object):
     @property
     def Cat12_r(self):
         cname = "Cat12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "Cat12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7588,7 +7589,7 @@ class Cmaps(object):
     @property
     def GHRSST_anomaly(self):
         cname = "GHRSST_anomaly"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GHRSST_anomaly.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7598,7 +7599,7 @@ class Cmaps(object):
     @property
     def GHRSST_anomaly_r(self):
         cname = "GHRSST_anomaly_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GHRSST_anomaly.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7608,7 +7609,7 @@ class Cmaps(object):
     @property
     def GMT_cool(self):
         cname = "GMT_cool"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_cool.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7618,7 +7619,7 @@ class Cmaps(object):
     @property
     def GMT_cool_r(self):
         cname = "GMT_cool_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_cool.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7628,7 +7629,7 @@ class Cmaps(object):
     @property
     def GMT_copper(self):
         cname = "GMT_copper"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_copper.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7638,7 +7639,7 @@ class Cmaps(object):
     @property
     def GMT_copper_r(self):
         cname = "GMT_copper_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_copper.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7648,7 +7649,7 @@ class Cmaps(object):
     @property
     def GMT_drywet(self):
         cname = "GMT_drywet"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_drywet.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7658,7 +7659,7 @@ class Cmaps(object):
     @property
     def GMT_drywet_r(self):
         cname = "GMT_drywet_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_drywet.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7668,7 +7669,7 @@ class Cmaps(object):
     @property
     def GMT_gebco(self):
         cname = "GMT_gebco"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_gebco.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7678,7 +7679,7 @@ class Cmaps(object):
     @property
     def GMT_gebco_r(self):
         cname = "GMT_gebco_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_gebco.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7688,7 +7689,7 @@ class Cmaps(object):
     @property
     def GMT_globe(self):
         cname = "GMT_globe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_globe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7698,7 +7699,7 @@ class Cmaps(object):
     @property
     def GMT_globe_r(self):
         cname = "GMT_globe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_globe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7708,7 +7709,7 @@ class Cmaps(object):
     @property
     def GMT_gray(self):
         cname = "GMT_gray"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7718,7 +7719,7 @@ class Cmaps(object):
     @property
     def GMT_gray_r(self):
         cname = "GMT_gray_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7728,7 +7729,7 @@ class Cmaps(object):
     @property
     def GMT_haxby(self):
         cname = "GMT_haxby"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_haxby.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7738,7 +7739,7 @@ class Cmaps(object):
     @property
     def GMT_haxby_r(self):
         cname = "GMT_haxby_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_haxby.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7748,7 +7749,7 @@ class Cmaps(object):
     @property
     def GMT_hot(self):
         cname = "GMT_hot"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_hot.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7758,7 +7759,7 @@ class Cmaps(object):
     @property
     def GMT_hot_r(self):
         cname = "GMT_hot_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_hot.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7768,7 +7769,7 @@ class Cmaps(object):
     @property
     def GMT_jet(self):
         cname = "GMT_jet"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_jet.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7778,7 +7779,7 @@ class Cmaps(object):
     @property
     def GMT_jet_r(self):
         cname = "GMT_jet_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_jet.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7788,7 +7789,7 @@ class Cmaps(object):
     @property
     def GMT_nighttime(self):
         cname = "GMT_nighttime"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_nighttime.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7798,7 +7799,7 @@ class Cmaps(object):
     @property
     def GMT_nighttime_r(self):
         cname = "GMT_nighttime_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_nighttime.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7808,7 +7809,7 @@ class Cmaps(object):
     @property
     def GMT_no_green(self):
         cname = "GMT_no_green"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_no_green.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7818,7 +7819,7 @@ class Cmaps(object):
     @property
     def GMT_no_green_r(self):
         cname = "GMT_no_green_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_no_green.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7828,7 +7829,7 @@ class Cmaps(object):
     @property
     def GMT_ocean(self):
         cname = "GMT_ocean"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_ocean.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7838,7 +7839,7 @@ class Cmaps(object):
     @property
     def GMT_ocean_r(self):
         cname = "GMT_ocean_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_ocean.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7848,7 +7849,7 @@ class Cmaps(object):
     @property
     def GMT_paired(self):
         cname = "GMT_paired"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_paired.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7858,7 +7859,7 @@ class Cmaps(object):
     @property
     def GMT_paired_r(self):
         cname = "GMT_paired_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_paired.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7868,7 +7869,7 @@ class Cmaps(object):
     @property
     def GMT_panoply(self):
         cname = "GMT_panoply"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_panoply.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7878,7 +7879,7 @@ class Cmaps(object):
     @property
     def GMT_panoply_r(self):
         cname = "GMT_panoply_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_panoply.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7888,7 +7889,7 @@ class Cmaps(object):
     @property
     def GMT_polar(self):
         cname = "GMT_polar"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_polar.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7898,7 +7899,7 @@ class Cmaps(object):
     @property
     def GMT_polar_r(self):
         cname = "GMT_polar_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_polar.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7908,7 +7909,7 @@ class Cmaps(object):
     @property
     def GMT_red2green(self):
         cname = "GMT_red2green"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_red2green.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7918,7 +7919,7 @@ class Cmaps(object):
     @property
     def GMT_red2green_r(self):
         cname = "GMT_red2green_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_red2green.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7928,7 +7929,7 @@ class Cmaps(object):
     @property
     def GMT_relief(self):
         cname = "GMT_relief"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_relief.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7938,7 +7939,7 @@ class Cmaps(object):
     @property
     def GMT_relief_r(self):
         cname = "GMT_relief_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_relief.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7948,7 +7949,7 @@ class Cmaps(object):
     @property
     def GMT_relief_oceanonly(self):
         cname = "GMT_relief_oceanonly"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_relief_oceanonly.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7958,7 +7959,7 @@ class Cmaps(object):
     @property
     def GMT_relief_oceanonly_r(self):
         cname = "GMT_relief_oceanonly_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_relief_oceanonly.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7968,7 +7969,7 @@ class Cmaps(object):
     @property
     def GMT_seis(self):
         cname = "GMT_seis"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_seis.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7978,7 +7979,7 @@ class Cmaps(object):
     @property
     def GMT_seis_r(self):
         cname = "GMT_seis_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_seis.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -7988,7 +7989,7 @@ class Cmaps(object):
     @property
     def GMT_split(self):
         cname = "GMT_split"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_split.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -7998,7 +7999,7 @@ class Cmaps(object):
     @property
     def GMT_split_r(self):
         cname = "GMT_split_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_split.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8008,7 +8009,7 @@ class Cmaps(object):
     @property
     def GMT_topo(self):
         cname = "GMT_topo"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_topo.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8018,7 +8019,7 @@ class Cmaps(object):
     @property
     def GMT_topo_r(self):
         cname = "GMT_topo_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_topo.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8028,7 +8029,7 @@ class Cmaps(object):
     @property
     def GMT_wysiwyg(self):
         cname = "GMT_wysiwyg"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_wysiwyg.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8038,7 +8039,7 @@ class Cmaps(object):
     @property
     def GMT_wysiwyg_r(self):
         cname = "GMT_wysiwyg_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_wysiwyg.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8048,7 +8049,7 @@ class Cmaps(object):
     @property
     def GMT_wysiwygcont(self):
         cname = "GMT_wysiwygcont"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_wysiwygcont.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8058,7 +8059,7 @@ class Cmaps(object):
     @property
     def GMT_wysiwygcont_r(self):
         cname = "GMT_wysiwygcont_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GMT_wysiwygcont.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8068,7 +8069,7 @@ class Cmaps(object):
     @property
     def GSFC_landsat_udf_density(self):
         cname = "GSFC_landsat_udf_density"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GSFC_landsat_udf_density.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8078,7 +8079,7 @@ class Cmaps(object):
     @property
     def GSFC_landsat_udf_density_r(self):
         cname = "GSFC_landsat_udf_density_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GSFC_landsat_udf_density.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8088,7 +8089,7 @@ class Cmaps(object):
     @property
     def GrayWhiteGray(self):
         cname = "GrayWhiteGray"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GrayWhiteGray.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8098,7 +8099,7 @@ class Cmaps(object):
     @property
     def GrayWhiteGray_r(self):
         cname = "GrayWhiteGray_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GrayWhiteGray.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8108,7 +8109,7 @@ class Cmaps(object):
     @property
     def GreenMagenta16(self):
         cname = "GreenMagenta16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GreenMagenta16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8118,7 +8119,7 @@ class Cmaps(object):
     @property
     def GreenMagenta16_r(self):
         cname = "GreenMagenta16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GreenMagenta16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8128,7 +8129,7 @@ class Cmaps(object):
     @property
     def GreenYellow(self):
         cname = "GreenYellow"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GreenYellow.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8138,7 +8139,7 @@ class Cmaps(object):
     @property
     def GreenYellow_r(self):
         cname = "GreenYellow_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "GreenYellow.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8148,7 +8149,7 @@ class Cmaps(object):
     @property
     def NCV_banded(self):
         cname = "NCV_banded"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_banded.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8158,7 +8159,7 @@ class Cmaps(object):
     @property
     def NCV_banded_r(self):
         cname = "NCV_banded_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_banded.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8168,7 +8169,7 @@ class Cmaps(object):
     @property
     def NCV_blu_red(self):
         cname = "NCV_blu_red"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_blu_red.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8178,7 +8179,7 @@ class Cmaps(object):
     @property
     def NCV_blu_red_r(self):
         cname = "NCV_blu_red_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_blu_red.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8188,7 +8189,7 @@ class Cmaps(object):
     @property
     def NCV_blue_red(self):
         cname = "NCV_blue_red"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_blue_red.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8198,7 +8199,7 @@ class Cmaps(object):
     @property
     def NCV_blue_red_r(self):
         cname = "NCV_blue_red_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_blue_red.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8208,7 +8209,7 @@ class Cmaps(object):
     @property
     def NCV_bright(self):
         cname = "NCV_bright"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_bright.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8218,7 +8219,7 @@ class Cmaps(object):
     @property
     def NCV_bright_r(self):
         cname = "NCV_bright_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_bright.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8228,7 +8229,7 @@ class Cmaps(object):
     @property
     def NCV_gebco(self):
         cname = "NCV_gebco"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_gebco.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8238,7 +8239,7 @@ class Cmaps(object):
     @property
     def NCV_gebco_r(self):
         cname = "NCV_gebco_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_gebco.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8248,7 +8249,7 @@ class Cmaps(object):
     @property
     def NCV_jaisnd(self):
         cname = "NCV_jaisnd"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_jaisnd.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8258,7 +8259,7 @@ class Cmaps(object):
     @property
     def NCV_jaisnd_r(self):
         cname = "NCV_jaisnd_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_jaisnd.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8268,7 +8269,7 @@ class Cmaps(object):
     @property
     def NCV_jet(self):
         cname = "NCV_jet"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_jet.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8278,7 +8279,7 @@ class Cmaps(object):
     @property
     def NCV_jet_r(self):
         cname = "NCV_jet_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_jet.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8288,7 +8289,7 @@ class Cmaps(object):
     @property
     def NCV_manga(self):
         cname = "NCV_manga"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_manga.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8298,7 +8299,7 @@ class Cmaps(object):
     @property
     def NCV_manga_r(self):
         cname = "NCV_manga_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_manga.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8308,7 +8309,7 @@ class Cmaps(object):
     @property
     def NCV_rainbow2(self):
         cname = "NCV_rainbow2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_rainbow2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8318,7 +8319,7 @@ class Cmaps(object):
     @property
     def NCV_rainbow2_r(self):
         cname = "NCV_rainbow2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_rainbow2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8328,7 +8329,7 @@ class Cmaps(object):
     @property
     def NCV_roullet(self):
         cname = "NCV_roullet"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_roullet.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8338,7 +8339,7 @@ class Cmaps(object):
     @property
     def NCV_roullet_r(self):
         cname = "NCV_roullet_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NCV_roullet.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8348,7 +8349,7 @@ class Cmaps(object):
     @property
     def NEO_div_vegetation_a(self):
         cname = "NEO_div_vegetation_a"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_div_vegetation_a.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8358,7 +8359,7 @@ class Cmaps(object):
     @property
     def NEO_div_vegetation_a_r(self):
         cname = "NEO_div_vegetation_a_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_div_vegetation_a.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8368,7 +8369,7 @@ class Cmaps(object):
     @property
     def NEO_div_vegetation_b(self):
         cname = "NEO_div_vegetation_b"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_div_vegetation_b.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8378,7 +8379,7 @@ class Cmaps(object):
     @property
     def NEO_div_vegetation_b_r(self):
         cname = "NEO_div_vegetation_b_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_div_vegetation_b.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8388,7 +8389,7 @@ class Cmaps(object):
     @property
     def NEO_div_vegetation_c(self):
         cname = "NEO_div_vegetation_c"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_div_vegetation_c.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8398,7 +8399,7 @@ class Cmaps(object):
     @property
     def NEO_div_vegetation_c_r(self):
         cname = "NEO_div_vegetation_c_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_div_vegetation_c.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8408,7 +8409,7 @@ class Cmaps(object):
     @property
     def NEO_modis_ndvi(self):
         cname = "NEO_modis_ndvi"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_modis_ndvi.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8418,7 +8419,7 @@ class Cmaps(object):
     @property
     def NEO_modis_ndvi_r(self):
         cname = "NEO_modis_ndvi_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NEO_modis_ndvi.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8428,7 +8429,7 @@ class Cmaps(object):
     @property
     def NMCRef(self):
         cname = "NMCRef"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NMCRef.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8438,7 +8439,7 @@ class Cmaps(object):
     @property
     def NMCRef_r(self):
         cname = "NMCRef_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NMCRef.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8448,7 +8449,7 @@ class Cmaps(object):
     @property
     def NMCVel(self):
         cname = "NMCVel"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NMCVel.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8458,7 +8459,7 @@ class Cmaps(object):
     @property
     def NMCVel_r(self):
         cname = "NMCVel_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NMCVel.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8468,7 +8469,7 @@ class Cmaps(object):
     @property
     def NOC_ndvi(self):
         cname = "NOC_ndvi"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NOC_ndvi.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8478,7 +8479,7 @@ class Cmaps(object):
     @property
     def NOC_ndvi_r(self):
         cname = "NOC_ndvi_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "NOC_ndvi.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8488,7 +8489,7 @@ class Cmaps(object):
     @property
     def OceanLakeLandSnow(self):
         cname = "OceanLakeLandSnow"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "OceanLakeLandSnow.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8498,7 +8499,7 @@ class Cmaps(object):
     @property
     def OceanLakeLandSnow_r(self):
         cname = "OceanLakeLandSnow_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "OceanLakeLandSnow.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8508,7 +8509,7 @@ class Cmaps(object):
     @property
     def SVG_Gallet13(self):
         cname = "SVG_Gallet13"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_Gallet13.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8518,7 +8519,7 @@ class Cmaps(object):
     @property
     def SVG_Gallet13_r(self):
         cname = "SVG_Gallet13_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_Gallet13.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8528,7 +8529,7 @@ class Cmaps(object):
     @property
     def SVG_Lindaa06(self):
         cname = "SVG_Lindaa06"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_Lindaa06.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8538,7 +8539,7 @@ class Cmaps(object):
     @property
     def SVG_Lindaa06_r(self):
         cname = "SVG_Lindaa06_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_Lindaa06.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8548,7 +8549,7 @@ class Cmaps(object):
     @property
     def SVG_Lindaa07(self):
         cname = "SVG_Lindaa07"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_Lindaa07.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8558,7 +8559,7 @@ class Cmaps(object):
     @property
     def SVG_Lindaa07_r(self):
         cname = "SVG_Lindaa07_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_Lindaa07.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8568,7 +8569,7 @@ class Cmaps(object):
     @property
     def SVG_bhw3_22(self):
         cname = "SVG_bhw3_22"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_bhw3_22.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8578,7 +8579,7 @@ class Cmaps(object):
     @property
     def SVG_bhw3_22_r(self):
         cname = "SVG_bhw3_22_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_bhw3_22.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8588,7 +8589,7 @@ class Cmaps(object):
     @property
     def SVG_es_landscape_79(self):
         cname = "SVG_es_landscape_79"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_es_landscape_79.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8598,7 +8599,7 @@ class Cmaps(object):
     @property
     def SVG_es_landscape_79_r(self):
         cname = "SVG_es_landscape_79_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_es_landscape_79.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8608,7 +8609,7 @@ class Cmaps(object):
     @property
     def SVG_feb_sunrise(self):
         cname = "SVG_feb_sunrise"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_feb_sunrise.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8618,7 +8619,7 @@ class Cmaps(object):
     @property
     def SVG_feb_sunrise_r(self):
         cname = "SVG_feb_sunrise_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_feb_sunrise.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8628,7 +8629,7 @@ class Cmaps(object):
     @property
     def SVG_foggy_sunrise(self):
         cname = "SVG_foggy_sunrise"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_foggy_sunrise.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8638,7 +8639,7 @@ class Cmaps(object):
     @property
     def SVG_foggy_sunrise_r(self):
         cname = "SVG_foggy_sunrise_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_foggy_sunrise.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8648,7 +8649,7 @@ class Cmaps(object):
     @property
     def SVG_fs2006(self):
         cname = "SVG_fs2006"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_fs2006.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8658,7 +8659,7 @@ class Cmaps(object):
     @property
     def SVG_fs2006_r(self):
         cname = "SVG_fs2006_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "SVG_fs2006.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8668,7 +8669,7 @@ class Cmaps(object):
     @property
     def StepSeq25(self):
         cname = "StepSeq25"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "StepSeq25.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8678,7 +8679,7 @@ class Cmaps(object):
     @property
     def StepSeq25_r(self):
         cname = "StepSeq25_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "StepSeq25.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8688,7 +8689,7 @@ class Cmaps(object):
     @property
     def UKM_hadcrut(self):
         cname = "UKM_hadcrut"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "UKM_hadcrut.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8698,7 +8699,7 @@ class Cmaps(object):
     @property
     def UKM_hadcrut_r(self):
         cname = "UKM_hadcrut_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "UKM_hadcrut.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8708,7 +8709,7 @@ class Cmaps(object):
     @property
     def ViBlGrWhYeOrRe(self):
         cname = "ViBlGrWhYeOrRe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "ViBlGrWhYeOrRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8718,7 +8719,7 @@ class Cmaps(object):
     @property
     def ViBlGrWhYeOrRe_r(self):
         cname = "ViBlGrWhYeOrRe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "ViBlGrWhYeOrRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8728,7 +8729,7 @@ class Cmaps(object):
     @property
     def WhBlGrYeRe(self):
         cname = "WhBlGrYeRe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhBlGrYeRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8738,7 +8739,7 @@ class Cmaps(object):
     @property
     def WhBlGrYeRe_r(self):
         cname = "WhBlGrYeRe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhBlGrYeRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8748,7 +8749,7 @@ class Cmaps(object):
     @property
     def WhBlReWh(self):
         cname = "WhBlReWh"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhBlReWh.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8758,7 +8759,7 @@ class Cmaps(object):
     @property
     def WhBlReWh_r(self):
         cname = "WhBlReWh_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhBlReWh.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8768,7 +8769,7 @@ class Cmaps(object):
     @property
     def WhViBlGrYeOrRe(self):
         cname = "WhViBlGrYeOrRe"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhViBlGrYeOrRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8778,7 +8779,7 @@ class Cmaps(object):
     @property
     def WhViBlGrYeOrRe_r(self):
         cname = "WhViBlGrYeOrRe_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhViBlGrYeOrRe.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8788,7 +8789,7 @@ class Cmaps(object):
     @property
     def WhViBlGrYeOrReWh(self):
         cname = "WhViBlGrYeOrReWh"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhViBlGrYeOrReWh.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8798,7 +8799,7 @@ class Cmaps(object):
     @property
     def WhViBlGrYeOrReWh_r(self):
         cname = "WhViBlGrYeOrReWh_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhViBlGrYeOrReWh.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8808,7 +8809,7 @@ class Cmaps(object):
     @property
     def WhiteBlue(self):
         cname = "WhiteBlue"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteBlue.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8818,7 +8819,7 @@ class Cmaps(object):
     @property
     def WhiteBlue_r(self):
         cname = "WhiteBlue_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteBlue.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8828,7 +8829,7 @@ class Cmaps(object):
     @property
     def WhiteBlueGreenYellowRed(self):
         cname = "WhiteBlueGreenYellowRed"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteBlueGreenYellowRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8838,7 +8839,7 @@ class Cmaps(object):
     @property
     def WhiteBlueGreenYellowRed_r(self):
         cname = "WhiteBlueGreenYellowRed_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteBlueGreenYellowRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8848,7 +8849,7 @@ class Cmaps(object):
     @property
     def WhiteGreen(self):
         cname = "WhiteGreen"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteGreen.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8858,7 +8859,7 @@ class Cmaps(object):
     @property
     def WhiteGreen_r(self):
         cname = "WhiteGreen_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteGreen.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8868,7 +8869,7 @@ class Cmaps(object):
     @property
     def WhiteYellowOrangeRed(self):
         cname = "WhiteYellowOrangeRed"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteYellowOrangeRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8878,7 +8879,7 @@ class Cmaps(object):
     @property
     def WhiteYellowOrangeRed_r(self):
         cname = "WhiteYellowOrangeRed_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "WhiteYellowOrangeRed.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8888,7 +8889,7 @@ class Cmaps(object):
     @property
     def amwg(self):
         cname = "amwg"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "amwg.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8898,7 +8899,7 @@ class Cmaps(object):
     @property
     def amwg_r(self):
         cname = "amwg_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "amwg.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8908,7 +8909,7 @@ class Cmaps(object):
     @property
     def amwg256(self):
         cname = "amwg256"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "amwg256.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8918,7 +8919,7 @@ class Cmaps(object):
     @property
     def amwg256_r(self):
         cname = "amwg256_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "amwg256.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8928,7 +8929,7 @@ class Cmaps(object):
     @property
     def amwg_blueyellowred(self):
         cname = "amwg_blueyellowred"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "amwg_blueyellowred.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8938,7 +8939,7 @@ class Cmaps(object):
     @property
     def amwg_blueyellowred_r(self):
         cname = "amwg_blueyellowred_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "amwg_blueyellowred.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8948,7 +8949,7 @@ class Cmaps(object):
     @property
     def cb_9step(self):
         cname = "cb_9step"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cb_9step.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8958,7 +8959,7 @@ class Cmaps(object):
     @property
     def cb_9step_r(self):
         cname = "cb_9step_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cb_9step.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8968,7 +8969,7 @@ class Cmaps(object):
     @property
     def cb_rainbow(self):
         cname = "cb_rainbow"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cb_rainbow.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8978,7 +8979,7 @@ class Cmaps(object):
     @property
     def cb_rainbow_r(self):
         cname = "cb_rainbow_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cb_rainbow.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -8988,7 +8989,7 @@ class Cmaps(object):
     @property
     def cb_rainbow_inv(self):
         cname = "cb_rainbow_inv"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cb_rainbow_inv.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -8998,7 +8999,7 @@ class Cmaps(object):
     @property
     def cb_rainbow_inv_r(self):
         cname = "cb_rainbow_inv_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cb_rainbow_inv.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9008,7 +9009,7 @@ class Cmaps(object):
     @property
     def circular_0(self):
         cname = "circular_0"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "circular_0.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9018,7 +9019,7 @@ class Cmaps(object):
     @property
     def circular_0_r(self):
         cname = "circular_0_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "circular_0.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9028,7 +9029,7 @@ class Cmaps(object):
     @property
     def circular_1(self):
         cname = "circular_1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "circular_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9038,7 +9039,7 @@ class Cmaps(object):
     @property
     def circular_1_r(self):
         cname = "circular_1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "circular_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9048,7 +9049,7 @@ class Cmaps(object):
     @property
     def circular_2(self):
         cname = "circular_2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "circular_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9058,7 +9059,7 @@ class Cmaps(object):
     @property
     def circular_2_r(self):
         cname = "circular_2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "circular_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9068,7 +9069,7 @@ class Cmaps(object):
     @property
     def cividis(self):
         cname = "cividis"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cividis.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9078,7 +9079,7 @@ class Cmaps(object):
     @property
     def cividis_r(self):
         cname = "cividis_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cividis.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9088,7 +9089,7 @@ class Cmaps(object):
     @property
     def cmp_b2r(self):
         cname = "cmp_b2r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cmp_b2r.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9098,7 +9099,7 @@ class Cmaps(object):
     @property
     def cmp_b2r_r(self):
         cname = "cmp_b2r_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cmp_b2r.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9108,7 +9109,7 @@ class Cmaps(object):
     @property
     def cmp_flux(self):
         cname = "cmp_flux"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cmp_flux.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9118,7 +9119,7 @@ class Cmaps(object):
     @property
     def cmp_flux_r(self):
         cname = "cmp_flux_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cmp_flux.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9128,7 +9129,7 @@ class Cmaps(object):
     @property
     def cmp_haxby(self):
         cname = "cmp_haxby"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cmp_haxby.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9138,7 +9139,7 @@ class Cmaps(object):
     @property
     def cmp_haxby_r(self):
         cname = "cmp_haxby_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cmp_haxby.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9148,7 +9149,7 @@ class Cmaps(object):
     @property
     def cosam(self):
         cname = "cosam"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cosam.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9158,7 +9159,7 @@ class Cmaps(object):
     @property
     def cosam_r(self):
         cname = "cosam_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cosam.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9168,7 +9169,7 @@ class Cmaps(object):
     @property
     def cosam12(self):
         cname = "cosam12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cosam12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9178,7 +9179,7 @@ class Cmaps(object):
     @property
     def cosam12_r(self):
         cname = "cosam12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cosam12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9188,7 +9189,7 @@ class Cmaps(object):
     @property
     def cyclic(self):
         cname = "cyclic"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cyclic.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9198,7 +9199,7 @@ class Cmaps(object):
     @property
     def cyclic_r(self):
         cname = "cyclic_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "cyclic.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9208,7 +9209,7 @@ class Cmaps(object):
     @property
     def default(self):
         cname = "default"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "default.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9218,7 +9219,7 @@ class Cmaps(object):
     @property
     def default_r(self):
         cname = "default_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "default.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9228,7 +9229,7 @@ class Cmaps(object):
     @property
     def detail(self):
         cname = "detail"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "detail.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9238,7 +9239,7 @@ class Cmaps(object):
     @property
     def detail_r(self):
         cname = "detail_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "detail.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9248,7 +9249,7 @@ class Cmaps(object):
     @property
     def drought_severity(self):
         cname = "drought_severity"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "drought_severity.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9258,7 +9259,7 @@ class Cmaps(object):
     @property
     def drought_severity_r(self):
         cname = "drought_severity_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "drought_severity.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9268,7 +9269,7 @@ class Cmaps(object):
     @property
     def example(self):
         cname = "example"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "example.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9278,7 +9279,7 @@ class Cmaps(object):
     @property
     def example_r(self):
         cname = "example_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "example.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9288,7 +9289,7 @@ class Cmaps(object):
     @property
     def extrema(self):
         cname = "extrema"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "extrema.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9298,7 +9299,7 @@ class Cmaps(object):
     @property
     def extrema_r(self):
         cname = "extrema_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "extrema.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9308,7 +9309,7 @@ class Cmaps(object):
     @property
     def gauss3(self):
         cname = "gauss3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gauss3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9318,7 +9319,7 @@ class Cmaps(object):
     @property
     def gauss3_r(self):
         cname = "gauss3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gauss3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9328,7 +9329,7 @@ class Cmaps(object):
     @property
     def grads_default(self):
         cname = "grads_default"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "grads_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9338,7 +9339,7 @@ class Cmaps(object):
     @property
     def grads_default_r(self):
         cname = "grads_default_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "grads_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9348,7 +9349,7 @@ class Cmaps(object):
     @property
     def grads_rainbow(self):
         cname = "grads_rainbow"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "grads_rainbow.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9358,7 +9359,7 @@ class Cmaps(object):
     @property
     def grads_rainbow_r(self):
         cname = "grads_rainbow_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "grads_rainbow.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9368,7 +9369,7 @@ class Cmaps(object):
     @property
     def gscyclic(self):
         cname = "gscyclic"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gscyclic.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9378,7 +9379,7 @@ class Cmaps(object):
     @property
     def gscyclic_r(self):
         cname = "gscyclic_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gscyclic.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9388,7 +9389,7 @@ class Cmaps(object):
     @property
     def gsdtol(self):
         cname = "gsdtol"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gsdtol.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9398,7 +9399,7 @@ class Cmaps(object):
     @property
     def gsdtol_r(self):
         cname = "gsdtol_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gsdtol.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9408,7 +9409,7 @@ class Cmaps(object):
     @property
     def gsltod(self):
         cname = "gsltod"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gsltod.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9418,7 +9419,7 @@ class Cmaps(object):
     @property
     def gsltod_r(self):
         cname = "gsltod_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gsltod.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9428,7 +9429,7 @@ class Cmaps(object):
     @property
     def gui_default(self):
         cname = "gui_default"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gui_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9438,7 +9439,7 @@ class Cmaps(object):
     @property
     def gui_default_r(self):
         cname = "gui_default_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "gui_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9448,7 +9449,7 @@ class Cmaps(object):
     @property
     def helix(self):
         cname = "helix"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "helix.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9458,7 +9459,7 @@ class Cmaps(object):
     @property
     def helix_r(self):
         cname = "helix_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "helix.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9468,7 +9469,7 @@ class Cmaps(object):
     @property
     def helix1(self):
         cname = "helix1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "helix1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9478,7 +9479,7 @@ class Cmaps(object):
     @property
     def helix1_r(self):
         cname = "helix1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "helix1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9488,7 +9489,7 @@ class Cmaps(object):
     @property
     def hlu_default(self):
         cname = "hlu_default"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hlu_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9498,7 +9499,7 @@ class Cmaps(object):
     @property
     def hlu_default_r(self):
         cname = "hlu_default_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hlu_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9508,7 +9509,7 @@ class Cmaps(object):
     @property
     def hotcold_18lev(self):
         cname = "hotcold_18lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hotcold_18lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9518,7 +9519,7 @@ class Cmaps(object):
     @property
     def hotcold_18lev_r(self):
         cname = "hotcold_18lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hotcold_18lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9528,7 +9529,7 @@ class Cmaps(object):
     @property
     def hotcolr_19lev(self):
         cname = "hotcolr_19lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hotcolr_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9538,7 +9539,7 @@ class Cmaps(object):
     @property
     def hotcolr_19lev_r(self):
         cname = "hotcolr_19lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hotcolr_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9548,7 +9549,7 @@ class Cmaps(object):
     @property
     def hotres(self):
         cname = "hotres"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hotres.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9558,7 +9559,7 @@ class Cmaps(object):
     @property
     def hotres_r(self):
         cname = "hotres_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "hotres.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9568,7 +9569,7 @@ class Cmaps(object):
     @property
     def lithology(self):
         cname = "lithology"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "lithology.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9578,7 +9579,7 @@ class Cmaps(object):
     @property
     def lithology_r(self):
         cname = "lithology_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "lithology.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9588,7 +9589,7 @@ class Cmaps(object):
     @property
     def matlab_hot(self):
         cname = "matlab_hot"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_hot.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9598,7 +9599,7 @@ class Cmaps(object):
     @property
     def matlab_hot_r(self):
         cname = "matlab_hot_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_hot.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9608,7 +9609,7 @@ class Cmaps(object):
     @property
     def matlab_hsv(self):
         cname = "matlab_hsv"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_hsv.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9618,7 +9619,7 @@ class Cmaps(object):
     @property
     def matlab_hsv_r(self):
         cname = "matlab_hsv_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_hsv.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9628,7 +9629,7 @@ class Cmaps(object):
     @property
     def matlab_jet(self):
         cname = "matlab_jet"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_jet.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9638,7 +9639,7 @@ class Cmaps(object):
     @property
     def matlab_jet_r(self):
         cname = "matlab_jet_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_jet.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9648,7 +9649,7 @@ class Cmaps(object):
     @property
     def matlab_lines(self):
         cname = "matlab_lines"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_lines.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9658,7 +9659,7 @@ class Cmaps(object):
     @property
     def matlab_lines_r(self):
         cname = "matlab_lines_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "matlab_lines.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9668,7 +9669,7 @@ class Cmaps(object):
     @property
     def mch_default(self):
         cname = "mch_default"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "mch_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9678,7 +9679,7 @@ class Cmaps(object):
     @property
     def mch_default_r(self):
         cname = "mch_default_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "mch_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9688,7 +9689,7 @@ class Cmaps(object):
     @property
     def ncl_default(self):
         cname = "ncl_default"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "ncl_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9698,7 +9699,7 @@ class Cmaps(object):
     @property
     def ncl_default_r(self):
         cname = "ncl_default_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "ncl_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9708,7 +9709,7 @@ class Cmaps(object):
     @property
     def ncview_default(self):
         cname = "ncview_default"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "ncview_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9718,7 +9719,7 @@ class Cmaps(object):
     @property
     def ncview_default_r(self):
         cname = "ncview_default_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "ncview_default.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9728,7 +9729,7 @@ class Cmaps(object):
     @property
     def nice_gfdl(self):
         cname = "nice_gfdl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "nice_gfdl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9738,7 +9739,7 @@ class Cmaps(object):
     @property
     def nice_gfdl_r(self):
         cname = "nice_gfdl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "nice_gfdl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9748,7 +9749,7 @@ class Cmaps(object):
     @property
     def nrl_sirkes(self):
         cname = "nrl_sirkes"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "nrl_sirkes.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9758,7 +9759,7 @@ class Cmaps(object):
     @property
     def nrl_sirkes_r(self):
         cname = "nrl_sirkes_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "nrl_sirkes.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9768,7 +9769,7 @@ class Cmaps(object):
     @property
     def nrl_sirkes_nowhite(self):
         cname = "nrl_sirkes_nowhite"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "nrl_sirkes_nowhite.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9778,7 +9779,7 @@ class Cmaps(object):
     @property
     def nrl_sirkes_nowhite_r(self):
         cname = "nrl_sirkes_nowhite_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "nrl_sirkes_nowhite.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9788,7 +9789,7 @@ class Cmaps(object):
     @property
     def perc2_9lev(self):
         cname = "perc2_9lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "perc2_9lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9798,7 +9799,7 @@ class Cmaps(object):
     @property
     def perc2_9lev_r(self):
         cname = "perc2_9lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "perc2_9lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9808,7 +9809,7 @@ class Cmaps(object):
     @property
     def percent_11lev(self):
         cname = "percent_11lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "percent_11lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9818,7 +9819,7 @@ class Cmaps(object):
     @property
     def percent_11lev_r(self):
         cname = "percent_11lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "percent_11lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9828,7 +9829,7 @@ class Cmaps(object):
     @property
     def posneg_1(self):
         cname = "posneg_1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "posneg_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9838,7 +9839,7 @@ class Cmaps(object):
     @property
     def posneg_1_r(self):
         cname = "posneg_1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "posneg_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9848,7 +9849,7 @@ class Cmaps(object):
     @property
     def posneg_2(self):
         cname = "posneg_2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "posneg_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9858,7 +9859,7 @@ class Cmaps(object):
     @property
     def posneg_2_r(self):
         cname = "posneg_2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "posneg_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9868,7 +9869,7 @@ class Cmaps(object):
     @property
     def prcp_1(self):
         cname = "prcp_1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "prcp_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9878,7 +9879,7 @@ class Cmaps(object):
     @property
     def prcp_1_r(self):
         cname = "prcp_1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "prcp_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9888,7 +9889,7 @@ class Cmaps(object):
     @property
     def prcp_2(self):
         cname = "prcp_2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "prcp_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9898,7 +9899,7 @@ class Cmaps(object):
     @property
     def prcp_2_r(self):
         cname = "prcp_2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "prcp_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9908,7 +9909,7 @@ class Cmaps(object):
     @property
     def prcp_3(self):
         cname = "prcp_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "prcp_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9918,7 +9919,7 @@ class Cmaps(object):
     @property
     def prcp_3_r(self):
         cname = "prcp_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "prcp_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9928,7 +9929,7 @@ class Cmaps(object):
     @property
     def precip2_15lev(self):
         cname = "precip2_15lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip2_15lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9938,7 +9939,7 @@ class Cmaps(object):
     @property
     def precip2_15lev_r(self):
         cname = "precip2_15lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip2_15lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9948,7 +9949,7 @@ class Cmaps(object):
     @property
     def precip2_17lev(self):
         cname = "precip2_17lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip2_17lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9958,7 +9959,7 @@ class Cmaps(object):
     @property
     def precip2_17lev_r(self):
         cname = "precip2_17lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip2_17lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9968,7 +9969,7 @@ class Cmaps(object):
     @property
     def precip3_16lev(self):
         cname = "precip3_16lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip3_16lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9978,7 +9979,7 @@ class Cmaps(object):
     @property
     def precip3_16lev_r(self):
         cname = "precip3_16lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip3_16lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -9988,7 +9989,7 @@ class Cmaps(object):
     @property
     def precip4_11lev(self):
         cname = "precip4_11lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip4_11lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -9998,7 +9999,7 @@ class Cmaps(object):
     @property
     def precip4_11lev_r(self):
         cname = "precip4_11lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip4_11lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10008,7 +10009,7 @@ class Cmaps(object):
     @property
     def precip4_diff_19lev(self):
         cname = "precip4_diff_19lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip4_diff_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10018,7 +10019,7 @@ class Cmaps(object):
     @property
     def precip4_diff_19lev_r(self):
         cname = "precip4_diff_19lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip4_diff_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10028,7 +10029,7 @@ class Cmaps(object):
     @property
     def precip_11lev(self):
         cname = "precip_11lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip_11lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10038,7 +10039,7 @@ class Cmaps(object):
     @property
     def precip_11lev_r(self):
         cname = "precip_11lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip_11lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10048,7 +10049,7 @@ class Cmaps(object):
     @property
     def precip_diff_12lev(self):
         cname = "precip_diff_12lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip_diff_12lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10058,7 +10059,7 @@ class Cmaps(object):
     @property
     def precip_diff_12lev_r(self):
         cname = "precip_diff_12lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip_diff_12lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10068,7 +10069,7 @@ class Cmaps(object):
     @property
     def precip_diff_1lev(self):
         cname = "precip_diff_1lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip_diff_1lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10078,7 +10079,7 @@ class Cmaps(object):
     @property
     def precip_diff_1lev_r(self):
         cname = "precip_diff_1lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "precip_diff_1lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10088,7 +10089,7 @@ class Cmaps(object):
     @property
     def psgcap(self):
         cname = "psgcap"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "psgcap.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10098,7 +10099,7 @@ class Cmaps(object):
     @property
     def psgcap_r(self):
         cname = "psgcap_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "psgcap.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10108,7 +10109,7 @@ class Cmaps(object):
     @property
     def radar(self):
         cname = "radar"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "radar.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10118,7 +10119,7 @@ class Cmaps(object):
     @property
     def radar_r(self):
         cname = "radar_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "radar.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10128,7 +10129,7 @@ class Cmaps(object):
     @property
     def radar_1(self):
         cname = "radar_1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "radar_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10138,7 +10139,7 @@ class Cmaps(object):
     @property
     def radar_1_r(self):
         cname = "radar_1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "radar_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10148,7 +10149,7 @@ class Cmaps(object):
     @property
     def rainbow(self):
         cname = "rainbow"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10158,7 +10159,7 @@ class Cmaps(object):
     @property
     def rainbow_r(self):
         cname = "rainbow_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10168,7 +10169,7 @@ class Cmaps(object):
     @property
     def rainbow_gray(self):
         cname = "rainbow_gray"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow_gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10178,7 +10179,7 @@ class Cmaps(object):
     @property
     def rainbow_gray_r(self):
         cname = "rainbow_gray_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow_gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10188,7 +10189,7 @@ class Cmaps(object):
     @property
     def rainbow_white(self):
         cname = "rainbow_white"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow_white.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10198,7 +10199,7 @@ class Cmaps(object):
     @property
     def rainbow_white_r(self):
         cname = "rainbow_white_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow_white.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10208,7 +10209,7 @@ class Cmaps(object):
     @property
     def rainbow_white_gray(self):
         cname = "rainbow_white_gray"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow_white_gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10218,7 +10219,7 @@ class Cmaps(object):
     @property
     def rainbow_white_gray_r(self):
         cname = "rainbow_white_gray_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rainbow_white_gray.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10228,7 +10229,7 @@ class Cmaps(object):
     @property
     def rh_19lev(self):
         cname = "rh_19lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rh_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10238,7 +10239,7 @@ class Cmaps(object):
     @property
     def rh_19lev_r(self):
         cname = "rh_19lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "rh_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10248,7 +10249,7 @@ class Cmaps(object):
     @property
     def saw3(self):
         cname = "saw3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "saw3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10258,7 +10259,7 @@ class Cmaps(object):
     @property
     def saw3_r(self):
         cname = "saw3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "saw3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10268,7 +10269,7 @@ class Cmaps(object):
     @property
     def seaice_1(self):
         cname = "seaice_1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "seaice_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10278,7 +10279,7 @@ class Cmaps(object):
     @property
     def seaice_1_r(self):
         cname = "seaice_1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "seaice_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10288,7 +10289,7 @@ class Cmaps(object):
     @property
     def seaice_2(self):
         cname = "seaice_2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "seaice_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10298,7 +10299,7 @@ class Cmaps(object):
     @property
     def seaice_2_r(self):
         cname = "seaice_2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "seaice_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10308,7 +10309,7 @@ class Cmaps(object):
     @property
     def so4_21(self):
         cname = "so4_21"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "so4_21.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10318,7 +10319,7 @@ class Cmaps(object):
     @property
     def so4_21_r(self):
         cname = "so4_21_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "so4_21.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10328,7 +10329,7 @@ class Cmaps(object):
     @property
     def so4_23(self):
         cname = "so4_23"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "so4_23.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10338,7 +10339,7 @@ class Cmaps(object):
     @property
     def so4_23_r(self):
         cname = "so4_23_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "so4_23.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10348,7 +10349,7 @@ class Cmaps(object):
     @property
     def spread_15lev(self):
         cname = "spread_15lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "spread_15lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10358,7 +10359,7 @@ class Cmaps(object):
     @property
     def spread_15lev_r(self):
         cname = "spread_15lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "spread_15lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10368,7 +10369,7 @@ class Cmaps(object):
     @property
     def srip_reanalysis(self):
         cname = "srip_reanalysis"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "srip_reanalysis.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10378,7 +10379,7 @@ class Cmaps(object):
     @property
     def srip_reanalysis_r(self):
         cname = "srip_reanalysis_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "srip_reanalysis.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10388,7 +10389,7 @@ class Cmaps(object):
     @property
     def sunshine_9lev(self):
         cname = "sunshine_9lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "sunshine_9lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10398,7 +10399,7 @@ class Cmaps(object):
     @property
     def sunshine_9lev_r(self):
         cname = "sunshine_9lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "sunshine_9lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10408,7 +10409,7 @@ class Cmaps(object):
     @property
     def sunshine_diff_12lev(self):
         cname = "sunshine_diff_12lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "sunshine_diff_12lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10418,7 +10419,7 @@ class Cmaps(object):
     @property
     def sunshine_diff_12lev_r(self):
         cname = "sunshine_diff_12lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "sunshine_diff_12lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10428,7 +10429,7 @@ class Cmaps(object):
     @property
     def t2m_29lev(self):
         cname = "t2m_29lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "t2m_29lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10438,7 +10439,7 @@ class Cmaps(object):
     @property
     def t2m_29lev_r(self):
         cname = "t2m_29lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "t2m_29lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10448,7 +10449,7 @@ class Cmaps(object):
     @property
     def tbrAvg1(self):
         cname = "tbrAvg1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbrAvg1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10458,7 +10459,7 @@ class Cmaps(object):
     @property
     def tbrAvg1_r(self):
         cname = "tbrAvg1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbrAvg1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10468,7 +10469,7 @@ class Cmaps(object):
     @property
     def tbrStd1(self):
         cname = "tbrStd1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbrStd1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10478,7 +10479,7 @@ class Cmaps(object):
     @property
     def tbrStd1_r(self):
         cname = "tbrStd1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbrStd1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10488,7 +10489,7 @@ class Cmaps(object):
     @property
     def tbrVar1(self):
         cname = "tbrVar1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbrVar1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10498,7 +10499,7 @@ class Cmaps(object):
     @property
     def tbrVar1_r(self):
         cname = "tbrVar1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbrVar1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10508,7 +10509,7 @@ class Cmaps(object):
     @property
     def tbr_240_300(self):
         cname = "tbr_240_300"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbr_240_300.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10518,7 +10519,7 @@ class Cmaps(object):
     @property
     def tbr_240_300_r(self):
         cname = "tbr_240_300_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbr_240_300.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10528,7 +10529,7 @@ class Cmaps(object):
     @property
     def tbr_stdev_0_30(self):
         cname = "tbr_stdev_0_30"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbr_stdev_0_30.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10538,7 +10539,7 @@ class Cmaps(object):
     @property
     def tbr_stdev_0_30_r(self):
         cname = "tbr_stdev_0_30_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbr_stdev_0_30.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10548,7 +10549,7 @@ class Cmaps(object):
     @property
     def tbr_var_0_500(self):
         cname = "tbr_var_0_500"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbr_var_0_500.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10558,7 +10559,7 @@ class Cmaps(object):
     @property
     def tbr_var_0_500_r(self):
         cname = "tbr_var_0_500_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "tbr_var_0_500.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10568,7 +10569,7 @@ class Cmaps(object):
     @property
     def temp1(self):
         cname = "temp1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10578,7 +10579,7 @@ class Cmaps(object):
     @property
     def temp1_r(self):
         cname = "temp1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10588,7 +10589,7 @@ class Cmaps(object):
     @property
     def temp_19lev(self):
         cname = "temp_19lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10598,7 +10599,7 @@ class Cmaps(object):
     @property
     def temp_19lev_r(self):
         cname = "temp_19lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp_19lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10608,7 +10609,7 @@ class Cmaps(object):
     @property
     def temp_diff_18lev(self):
         cname = "temp_diff_18lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp_diff_18lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10618,7 +10619,7 @@ class Cmaps(object):
     @property
     def temp_diff_18lev_r(self):
         cname = "temp_diff_18lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp_diff_18lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10628,7 +10629,7 @@ class Cmaps(object):
     @property
     def temp_diff_1lev(self):
         cname = "temp_diff_1lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp_diff_1lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10638,7 +10639,7 @@ class Cmaps(object):
     @property
     def temp_diff_1lev_r(self):
         cname = "temp_diff_1lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "temp_diff_1lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10648,7 +10649,7 @@ class Cmaps(object):
     @property
     def testcmap(self):
         cname = "testcmap"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "testcmap.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10658,7 +10659,7 @@ class Cmaps(object):
     @property
     def testcmap_r(self):
         cname = "testcmap_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "testcmap.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10668,7 +10669,7 @@ class Cmaps(object):
     @property
     def thelix(self):
         cname = "thelix"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "thelix.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10678,7 +10679,7 @@ class Cmaps(object):
     @property
     def thelix_r(self):
         cname = "thelix_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "thelix.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10688,7 +10689,7 @@ class Cmaps(object):
     @property
     def topo_15lev(self):
         cname = "topo_15lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "topo_15lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10698,7 +10699,7 @@ class Cmaps(object):
     @property
     def topo_15lev_r(self):
         cname = "topo_15lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "topo_15lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10708,7 +10709,7 @@ class Cmaps(object):
     @property
     def uniform(self):
         cname = "uniform"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "uniform.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10718,7 +10719,7 @@ class Cmaps(object):
     @property
     def uniform_r(self):
         cname = "uniform_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "uniform.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10728,7 +10729,7 @@ class Cmaps(object):
     @property
     def vegetation_ClarkU(self):
         cname = "vegetation_ClarkU"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "vegetation_ClarkU.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10738,7 +10739,7 @@ class Cmaps(object):
     @property
     def vegetation_ClarkU_r(self):
         cname = "vegetation_ClarkU_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "vegetation_ClarkU.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10748,7 +10749,7 @@ class Cmaps(object):
     @property
     def vegetation_modis(self):
         cname = "vegetation_modis"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "vegetation_modis.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10758,7 +10759,7 @@ class Cmaps(object):
     @property
     def vegetation_modis_r(self):
         cname = "vegetation_modis_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "vegetation_modis.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10768,7 +10769,7 @@ class Cmaps(object):
     @property
     def wgne15(self):
         cname = "wgne15"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wgne15.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10778,7 +10779,7 @@ class Cmaps(object):
     @property
     def wgne15_r(self):
         cname = "wgne15_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wgne15.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10788,7 +10789,7 @@ class Cmaps(object):
     @property
     def wh_bl_gr_ye_re(self):
         cname = "wh_bl_gr_ye_re"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wh_bl_gr_ye_re.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10798,7 +10799,7 @@ class Cmaps(object):
     @property
     def wh_bl_gr_ye_re_r(self):
         cname = "wh_bl_gr_ye_re_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wh_bl_gr_ye_re.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10808,7 +10809,7 @@ class Cmaps(object):
     @property
     def wind_17lev(self):
         cname = "wind_17lev"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wind_17lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10818,7 +10819,7 @@ class Cmaps(object):
     @property
     def wind_17lev_r(self):
         cname = "wind_17lev_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wind_17lev.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10828,7 +10829,7 @@ class Cmaps(object):
     @property
     def wxpEnIR(self):
         cname = "wxpEnIR"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wxpEnIR.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10838,7 +10839,7 @@ class Cmaps(object):
     @property
     def wxpEnIR_r(self):
         cname = "wxpEnIR_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "ncar_ncl",  "wxpEnIR.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10848,7 +10849,7 @@ class Cmaps(object):
     @property
     def acton(self):
         cname = "acton"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "acton.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10858,7 +10859,7 @@ class Cmaps(object):
     @property
     def acton_r(self):
         cname = "acton_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "acton.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10868,7 +10869,7 @@ class Cmaps(object):
     @property
     def bamako(self):
         cname = "bamako"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "bamako.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10878,7 +10879,7 @@ class Cmaps(object):
     @property
     def bamako_r(self):
         cname = "bamako_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "bamako.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10888,7 +10889,7 @@ class Cmaps(object):
     @property
     def batlow(self):
         cname = "batlow"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "batlow.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10898,7 +10899,7 @@ class Cmaps(object):
     @property
     def batlow_r(self):
         cname = "batlow_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "batlow.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10908,7 +10909,7 @@ class Cmaps(object):
     @property
     def berlin(self):
         cname = "berlin"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "berlin.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10918,7 +10919,7 @@ class Cmaps(object):
     @property
     def berlin_r(self):
         cname = "berlin_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "berlin.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10928,7 +10929,7 @@ class Cmaps(object):
     @property
     def bilbao(self):
         cname = "bilbao"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "bilbao.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10938,7 +10939,7 @@ class Cmaps(object):
     @property
     def bilbao_r(self):
         cname = "bilbao_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "bilbao.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10948,7 +10949,7 @@ class Cmaps(object):
     @property
     def broc(self):
         cname = "broc"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "broc.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10958,7 +10959,7 @@ class Cmaps(object):
     @property
     def broc_r(self):
         cname = "broc_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "broc.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10968,7 +10969,7 @@ class Cmaps(object):
     @property
     def buda(self):
         cname = "buda"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "buda.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10978,7 +10979,7 @@ class Cmaps(object):
     @property
     def buda_r(self):
         cname = "buda_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "buda.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -10988,7 +10989,7 @@ class Cmaps(object):
     @property
     def cork(self):
         cname = "cork"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "cork.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -10998,7 +10999,7 @@ class Cmaps(object):
     @property
     def cork_r(self):
         cname = "cork_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "cork.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11008,7 +11009,7 @@ class Cmaps(object):
     @property
     def davos(self):
         cname = "davos"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "davos.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11018,7 +11019,7 @@ class Cmaps(object):
     @property
     def davos_r(self):
         cname = "davos_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "davos.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11028,7 +11029,7 @@ class Cmaps(object):
     @property
     def devon(self):
         cname = "devon"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "devon.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11038,7 +11039,7 @@ class Cmaps(object):
     @property
     def devon_r(self):
         cname = "devon_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "devon.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11048,7 +11049,7 @@ class Cmaps(object):
     @property
     def grayc(self):
         cname = "grayc"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "grayc.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11058,7 +11059,7 @@ class Cmaps(object):
     @property
     def grayc_r(self):
         cname = "grayc_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "grayc.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11068,7 +11069,7 @@ class Cmaps(object):
     @property
     def hawaii(self):
         cname = "hawaii"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "hawaii.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11078,7 +11079,7 @@ class Cmaps(object):
     @property
     def hawaii_r(self):
         cname = "hawaii_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "hawaii.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11088,7 +11089,7 @@ class Cmaps(object):
     @property
     def imola(self):
         cname = "imola"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "imola.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11098,7 +11099,7 @@ class Cmaps(object):
     @property
     def imola_r(self):
         cname = "imola_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "imola.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11108,7 +11109,7 @@ class Cmaps(object):
     @property
     def lajolla(self):
         cname = "lajolla"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "lajolla.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11118,7 +11119,7 @@ class Cmaps(object):
     @property
     def lajolla_r(self):
         cname = "lajolla_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "lajolla.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11128,7 +11129,7 @@ class Cmaps(object):
     @property
     def lapaz(self):
         cname = "lapaz"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "lapaz.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11138,7 +11139,7 @@ class Cmaps(object):
     @property
     def lapaz_r(self):
         cname = "lapaz_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "lapaz.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11148,7 +11149,7 @@ class Cmaps(object):
     @property
     def lisbon(self):
         cname = "lisbon"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "lisbon.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11158,7 +11159,7 @@ class Cmaps(object):
     @property
     def lisbon_r(self):
         cname = "lisbon_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "lisbon.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11168,7 +11169,7 @@ class Cmaps(object):
     @property
     def nuuk(self):
         cname = "nuuk"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "nuuk.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11178,7 +11179,7 @@ class Cmaps(object):
     @property
     def nuuk_r(self):
         cname = "nuuk_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "nuuk.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11188,7 +11189,7 @@ class Cmaps(object):
     @property
     def oleron(self):
         cname = "oleron"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "oleron.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11198,7 +11199,7 @@ class Cmaps(object):
     @property
     def oleron_r(self):
         cname = "oleron_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "oleron.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11208,7 +11209,7 @@ class Cmaps(object):
     @property
     def oslo(self):
         cname = "oslo"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "oslo.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11218,7 +11219,7 @@ class Cmaps(object):
     @property
     def oslo_r(self):
         cname = "oslo_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "oslo.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11228,7 +11229,7 @@ class Cmaps(object):
     @property
     def roma(self):
         cname = "roma"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "roma.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11238,7 +11239,7 @@ class Cmaps(object):
     @property
     def roma_r(self):
         cname = "roma_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "roma.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11248,7 +11249,7 @@ class Cmaps(object):
     @property
     def tofino(self):
         cname = "tofino"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "tofino.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11258,7 +11259,7 @@ class Cmaps(object):
     @property
     def tofino_r(self):
         cname = "tofino_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "tofino.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11268,7 +11269,7 @@ class Cmaps(object):
     @property
     def tokyo(self):
         cname = "tokyo"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "tokyo.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11278,7 +11279,7 @@ class Cmaps(object):
     @property
     def tokyo_r(self):
         cname = "tokyo_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "tokyo.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11288,7 +11289,7 @@ class Cmaps(object):
     @property
     def turku(self):
         cname = "turku"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "turku.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11298,7 +11299,7 @@ class Cmaps(object):
     @property
     def turku_r(self):
         cname = "turku_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "turku.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11308,7 +11309,7 @@ class Cmaps(object):
     @property
     def vik(self):
         cname = "vik"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "vik.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11318,7 +11319,7 @@ class Cmaps(object):
     @property
     def vik_r(self):
         cname = "vik_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "scientific",  "vik.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11328,7 +11329,7 @@ class Cmaps(object):
     @property
     def bluered_12(self):
         cname = "bluered_12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "bluered_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11338,7 +11339,7 @@ class Cmaps(object):
     @property
     def bluered_12_r(self):
         cname = "bluered_12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "bluered_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11348,7 +11349,7 @@ class Cmaps(object):
     @property
     def bluered_6(self):
         cname = "bluered_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "bluered_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11358,7 +11359,7 @@ class Cmaps(object):
     @property
     def bluered_6_r(self):
         cname = "bluered_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "bluered_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11368,7 +11369,7 @@ class Cmaps(object):
     @property
     def colorblind_10(self):
         cname = "colorblind_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "colorblind_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11378,7 +11379,7 @@ class Cmaps(object):
     @property
     def colorblind_10_r(self):
         cname = "colorblind_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "colorblind_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11388,7 +11389,7 @@ class Cmaps(object):
     @property
     def gray_5(self):
         cname = "gray_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "gray_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11398,7 +11399,7 @@ class Cmaps(object):
     @property
     def gray_5_r(self):
         cname = "gray_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "gray_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11408,7 +11409,7 @@ class Cmaps(object):
     @property
     def greenorange_12(self):
         cname = "greenorange_12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "greenorange_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11418,7 +11419,7 @@ class Cmaps(object):
     @property
     def greenorange_12_r(self):
         cname = "greenorange_12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "greenorange_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11428,7 +11429,7 @@ class Cmaps(object):
     @property
     def greenorange_6(self):
         cname = "greenorange_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "greenorange_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11438,7 +11439,7 @@ class Cmaps(object):
     @property
     def greenorange_6_r(self):
         cname = "greenorange_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "greenorange_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11448,7 +11449,7 @@ class Cmaps(object):
     @property
     def purplegray_12(self):
         cname = "purplegray_12"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "purplegray_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11458,7 +11459,7 @@ class Cmaps(object):
     @property
     def purplegray_12_r(self):
         cname = "purplegray_12_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "purplegray_12.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11468,7 +11469,7 @@ class Cmaps(object):
     @property
     def purplegray_6(self):
         cname = "purplegray_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "purplegray_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11478,7 +11479,7 @@ class Cmaps(object):
     @property
     def purplegray_6_r(self):
         cname = "purplegray_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "purplegray_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11488,7 +11489,7 @@ class Cmaps(object):
     @property
     def tableau_10(self):
         cname = "tableau_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableau_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11498,7 +11499,7 @@ class Cmaps(object):
     @property
     def tableau_10_r(self):
         cname = "tableau_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableau_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11508,7 +11509,7 @@ class Cmaps(object):
     @property
     def tableau_20(self):
         cname = "tableau_20"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableau_20.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11518,7 +11519,7 @@ class Cmaps(object):
     @property
     def tableau_20_r(self):
         cname = "tableau_20_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableau_20.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11528,7 +11529,7 @@ class Cmaps(object):
     @property
     def tableaulight_10(self):
         cname = "tableaulight_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableaulight_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11538,7 +11539,7 @@ class Cmaps(object):
     @property
     def tableaulight_10_r(self):
         cname = "tableaulight_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableaulight_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11548,7 +11549,7 @@ class Cmaps(object):
     @property
     def tableaumedium_10(self):
         cname = "tableaumedium_10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableaumedium_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11558,7 +11559,7 @@ class Cmaps(object):
     @property
     def tableaumedium_10_r(self):
         cname = "tableaumedium_10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "tableaumedium_10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11568,7 +11569,7 @@ class Cmaps(object):
     @property
     def trafficlight_9(self):
         cname = "trafficlight_9"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "trafficlight_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11578,7 +11579,7 @@ class Cmaps(object):
     @property
     def trafficlight_9_r(self):
         cname = "trafficlight_9_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "tableau",  "trafficlight_9.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11588,7 +11589,7 @@ class Cmaps(object):
     @property
     def b2_31(self):
         cname = "b2_31"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "b2_31.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11598,7 +11599,7 @@ class Cmaps(object):
     @property
     def b2_31_r(self):
         cname = "b2_31_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "b2_31.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11608,7 +11609,7 @@ class Cmaps(object):
     @property
     def bl_11(self):
         cname = "bl_11"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "bl_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11618,7 +11619,7 @@ class Cmaps(object):
     @property
     def bl_11_r(self):
         cname = "bl_11_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "bl_11.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11628,7 +11629,7 @@ class Cmaps(object):
     @property
     def blue_8_5g2(self):
         cname = "blue_8_5g2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_8_5g2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11638,7 +11639,7 @@ class Cmaps(object):
     @property
     def blue_8_5g2_r(self):
         cname = "blue_8_5g2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_8_5g2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11648,7 +11649,7 @@ class Cmaps(object):
     @property
     def blue_bl111(self):
         cname = "blue_bl111"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_bl111.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11658,7 +11659,7 @@ class Cmaps(object):
     @property
     def blue_bl111_r(self):
         cname = "blue_bl111_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_bl111.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11668,7 +11669,7 @@ class Cmaps(object):
     @property
     def blue_blgra2(self):
         cname = "blue_blgra2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_blgra2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11678,7 +11679,7 @@ class Cmaps(object):
     @property
     def blue_blgra2_r(self):
         cname = "blue_blgra2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_blgra2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11688,7 +11689,7 @@ class Cmaps(object):
     @property
     def blue_blue3(self):
         cname = "blue_blue3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_blue3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11698,7 +11699,7 @@ class Cmaps(object):
     @property
     def blue_blue3_r(self):
         cname = "blue_blue3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_blue3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11708,7 +11709,7 @@ class Cmaps(object):
     @property
     def blue_blueb1(self):
         cname = "blue_blueb1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_blueb1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11718,7 +11719,7 @@ class Cmaps(object):
     @property
     def blue_blueb1_r(self):
         cname = "blue_blueb1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_blueb1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11728,7 +11729,7 @@ class Cmaps(object):
     @property
     def blue_c16adjw(self):
         cname = "blue_c16adjw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_c16adjw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11738,7 +11739,7 @@ class Cmaps(object):
     @property
     def blue_c16adjw_r(self):
         cname = "blue_c16adjw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_c16adjw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11748,7 +11749,7 @@ class Cmaps(object):
     @property
     def blue_gblue(self):
         cname = "blue_gblue"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_gblue.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11758,7 +11759,7 @@ class Cmaps(object):
     @property
     def blue_gblue_r(self):
         cname = "blue_gblue_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_gblue.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11768,7 +11769,7 @@ class Cmaps(object):
     @property
     def blue_lbluec1(self):
         cname = "blue_lbluec1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_lbluec1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11778,7 +11779,7 @@ class Cmaps(object):
     @property
     def blue_lbluec1_r(self):
         cname = "blue_lbluec1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_lbluec1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11788,7 +11789,7 @@ class Cmaps(object):
     @property
     def blue_medb717b(self):
         cname = "blue_medb717b"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_medb717b.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11798,7 +11799,7 @@ class Cmaps(object):
     @property
     def blue_medb717b_r(self):
         cname = "blue_medb717b_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "blue_medb717b.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11808,7 +11809,7 @@ class Cmaps(object):
     @property
     def br4div(self):
         cname = "br4div"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "br4div.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11818,7 +11819,7 @@ class Cmaps(object):
     @property
     def br4div_r(self):
         cname = "br4div_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "br4div.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11828,7 +11829,7 @@ class Cmaps(object):
     @property
     def brown_br119a(self):
         cname = "brown_br119a"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_br119a.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11838,7 +11839,7 @@ class Cmaps(object):
     @property
     def brown_br119a_r(self):
         cname = "brown_br119a_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_br119a.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11848,7 +11849,7 @@ class Cmaps(object):
     @property
     def brown_browns(self):
         cname = "brown_browns"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_browns.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11858,7 +11859,7 @@ class Cmaps(object):
     @property
     def brown_browns_r(self):
         cname = "brown_browns_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_browns.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11868,7 +11869,7 @@ class Cmaps(object):
     @property
     def brown_brye1b(self):
         cname = "brown_brye1b"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_brye1b.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11878,7 +11879,7 @@ class Cmaps(object):
     @property
     def brown_brye1b_r(self):
         cname = "brown_brye1b_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_brye1b.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11888,7 +11889,7 @@ class Cmaps(object):
     @property
     def brown_grawarm1(self):
         cname = "brown_grawarm1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_grawarm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11898,7 +11899,7 @@ class Cmaps(object):
     @property
     def brown_grawarm1_r(self):
         cname = "brown_grawarm1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_grawarm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11908,7 +11909,7 @@ class Cmaps(object):
     @property
     def brown_orange1(self):
         cname = "brown_orange1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_orange1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11918,7 +11919,7 @@ class Cmaps(object):
     @property
     def brown_orange1_r(self):
         cname = "brown_orange1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_orange1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11928,7 +11929,7 @@ class Cmaps(object):
     @property
     def brown_ortanish1(self):
         cname = "brown_ortanish1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_ortanish1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11938,7 +11939,7 @@ class Cmaps(object):
     @property
     def brown_ortanish1_r(self):
         cname = "brown_ortanish1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_ortanish1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11948,7 +11949,7 @@ class Cmaps(object):
     @property
     def brown_peachy(self):
         cname = "brown_peachy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_peachy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11958,7 +11959,7 @@ class Cmaps(object):
     @property
     def brown_peachy_r(self):
         cname = "brown_peachy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_peachy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11968,7 +11969,7 @@ class Cmaps(object):
     @property
     def brown_red3b(self):
         cname = "brown_red3b"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_red3b.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11978,7 +11979,7 @@ class Cmaps(object):
     @property
     def brown_red3b_r(self):
         cname = "brown_red3b_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_red3b.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -11988,7 +11989,7 @@ class Cmaps(object):
     @property
     def brown_sable(self):
         cname = "brown_sable"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_sable.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -11998,7 +11999,7 @@ class Cmaps(object):
     @property
     def brown_sable_r(self):
         cname = "brown_sable_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_sable.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12008,7 +12009,7 @@ class Cmaps(object):
     @property
     def brown_vbrown1(self):
         cname = "brown_vbrown1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_vbrown1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12018,7 +12019,7 @@ class Cmaps(object):
     @property
     def brown_vbrown1_r(self):
         cname = "brown_vbrown1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "brown_vbrown1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12028,7 +12029,7 @@ class Cmaps(object):
     @property
     def browngray(self):
         cname = "browngray"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "browngray.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12038,7 +12039,7 @@ class Cmaps(object):
     @property
     def browngray_r(self):
         cname = "browngray_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "browngray.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12048,7 +12049,7 @@ class Cmaps(object):
     @property
     def bruce2(self):
         cname = "bruce2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "bruce2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12058,7 +12059,7 @@ class Cmaps(object):
     @property
     def bruce2_r(self):
         cname = "bruce2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "bruce2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12068,7 +12069,7 @@ class Cmaps(object):
     @property
     def c_7_16(self):
         cname = "c_7_16"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_7_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12078,7 +12079,7 @@ class Cmaps(object):
     @property
     def c_7_16_r(self):
         cname = "c_7_16_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_7_16.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12088,7 +12089,7 @@ class Cmaps(object):
     @property
     def c_blgr1(self):
         cname = "c_blgr1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_blgr1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12098,7 +12099,7 @@ class Cmaps(object):
     @property
     def c_blgr1_r(self):
         cname = "c_blgr1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_blgr1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12108,7 +12109,7 @@ class Cmaps(object):
     @property
     def c_pch1(self):
         cname = "c_pch1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_pch1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12118,7 +12119,7 @@ class Cmaps(object):
     @property
     def c_pch1_r(self):
         cname = "c_pch1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_pch1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12128,7 +12129,7 @@ class Cmaps(object):
     @property
     def c_violet1(self):
         cname = "c_violet1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_violet1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12138,7 +12139,7 @@ class Cmaps(object):
     @property
     def c_violet1_r(self):
         cname = "c_violet1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_violet1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12148,7 +12149,7 @@ class Cmaps(object):
     @property
     def c_yelpch1(self):
         cname = "c_yelpch1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_yelpch1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12158,7 +12159,7 @@ class Cmaps(object):
     @property
     def c_yelpch1_r(self):
         cname = "c_yelpch1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "c_yelpch1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12168,7 +12169,7 @@ class Cmaps(object):
     @property
     def colormap66(self):
         cname = "colormap66"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "colormap66.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12178,7 +12179,7 @@ class Cmaps(object):
     @property
     def colormap66_r(self):
         cname = "colormap66_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "colormap66.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12188,7 +12189,7 @@ class Cmaps(object):
     @property
     def d_blgr3(self):
         cname = "d_blgr3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "d_blgr3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12198,7 +12199,7 @@ class Cmaps(object):
     @property
     def d_blgr3_r(self):
         cname = "d_blgr3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "d_blgr3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12208,7 +12209,7 @@ class Cmaps(object):
     @property
     def d_seteq2(self):
         cname = "d_seteq2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "d_seteq2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12218,7 +12219,7 @@ class Cmaps(object):
     @property
     def d_seteq2_r(self):
         cname = "d_seteq2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "d_seteq2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12228,7 +12229,7 @@ class Cmaps(object):
     @property
     def dasy_grbr1(self):
         cname = "dasy_grbr1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "dasy_grbr1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12238,7 +12239,7 @@ class Cmaps(object):
     @property
     def dasy_grbr1_r(self):
         cname = "dasy_grbr1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "dasy_grbr1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12248,7 +12249,7 @@ class Cmaps(object):
     @property
     def discrete_Bg(self):
         cname = "discrete_Bg"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_Bg.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12258,7 +12259,7 @@ class Cmaps(object):
     @property
     def discrete_Bg_r(self):
         cname = "discrete_Bg_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_Bg.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12268,7 +12269,7 @@ class Cmaps(object):
     @property
     def discrete_Bo(self):
         cname = "discrete_Bo"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_Bo.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12278,7 +12279,7 @@ class Cmaps(object):
     @property
     def discrete_Bo_r(self):
         cname = "discrete_Bo_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_Bo.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12288,7 +12289,7 @@ class Cmaps(object):
     @property
     def discrete_autumn(self):
         cname = "discrete_autumn"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_autumn.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12298,7 +12299,7 @@ class Cmaps(object):
     @property
     def discrete_autumn_r(self):
         cname = "discrete_autumn_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_autumn.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12308,7 +12309,7 @@ class Cmaps(object):
     @property
     def discrete_dark(self):
         cname = "discrete_dark"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_dark.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12318,7 +12319,7 @@ class Cmaps(object):
     @property
     def discrete_dark_r(self):
         cname = "discrete_dark_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_dark.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12328,7 +12329,7 @@ class Cmaps(object):
     @property
     def discrete_light_aut(self):
         cname = "discrete_light_aut"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_light_aut.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12338,7 +12339,7 @@ class Cmaps(object):
     @property
     def discrete_light_aut_r(self):
         cname = "discrete_light_aut_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_light_aut.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12348,7 +12349,7 @@ class Cmaps(object):
     @property
     def discrete_muted(self):
         cname = "discrete_muted"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_muted.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12358,7 +12359,7 @@ class Cmaps(object):
     @property
     def discrete_muted_r(self):
         cname = "discrete_muted_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_muted.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12368,7 +12369,7 @@ class Cmaps(object):
     @property
     def discrete_vaneyck(self):
         cname = "discrete_vaneyck"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_vaneyck.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12378,7 +12379,7 @@ class Cmaps(object):
     @property
     def discrete_vaneyck_r(self):
         cname = "discrete_vaneyck_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "discrete_vaneyck.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12388,7 +12389,7 @@ class Cmaps(object):
     @property
     def div1_blue_orange(self):
         cname = "div1_blue_orange"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div1_blue_orange.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12398,7 +12399,7 @@ class Cmaps(object):
     @property
     def div1_blue_orange_r(self):
         cname = "div1_blue_orange_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div1_blue_orange.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12408,7 +12409,7 @@ class Cmaps(object):
     @property
     def div2_gray_gold(self):
         cname = "div2_gray_gold"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div2_gray_gold.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12418,7 +12419,7 @@ class Cmaps(object):
     @property
     def div2_gray_gold_r(self):
         cname = "div2_gray_gold_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div2_gray_gold.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12428,7 +12429,7 @@ class Cmaps(object):
     @property
     def div3_green_brown(self):
         cname = "div3_green_brown"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div3_green_brown.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12438,7 +12439,7 @@ class Cmaps(object):
     @property
     def div3_green_brown_r(self):
         cname = "div3_green_brown_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div3_green_brown.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12448,7 +12449,7 @@ class Cmaps(object):
     @property
     def div5_asym_Ob(self):
         cname = "div5_asym_Ob"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div5_asym_Ob.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12458,7 +12459,7 @@ class Cmaps(object):
     @property
     def div5_asym_Ob_r(self):
         cname = "div5_asym_Ob_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "div5_asym_Ob.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12468,7 +12469,7 @@ class Cmaps(object):
     @property
     def fushia_red_pink1(self):
         cname = "fushia_red_pink1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "fushia_red_pink1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12478,7 +12479,7 @@ class Cmaps(object):
     @property
     def fushia_red_pink1_r(self):
         cname = "fushia_red_pink1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "fushia_red_pink1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12488,7 +12489,7 @@ class Cmaps(object):
     @property
     def green_9_17e(self):
         cname = "green_9_17e"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_9_17e.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12498,7 +12499,7 @@ class Cmaps(object):
     @property
     def green_9_17e_r(self):
         cname = "green_9_17e_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_9_17e.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12508,7 +12509,7 @@ class Cmaps(object):
     @property
     def green_c_gry1(self):
         cname = "green_c_gry1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_c_gry1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12518,7 +12519,7 @@ class Cmaps(object):
     @property
     def green_c_gry1_r(self):
         cname = "green_c_gry1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_c_gry1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12528,7 +12529,7 @@ class Cmaps(object):
     @property
     def green_gr1214b(self):
         cname = "green_gr1214b"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_gr1214b.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12538,7 +12539,7 @@ class Cmaps(object):
     @property
     def green_gr1214b_r(self):
         cname = "green_gr1214b_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_gr1214b.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12548,7 +12549,7 @@ class Cmaps(object):
     @property
     def green_green1(self):
         cname = "green_green1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_green1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12558,7 +12559,7 @@ class Cmaps(object):
     @property
     def green_green1_r(self):
         cname = "green_green1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_green1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12568,7 +12569,7 @@ class Cmaps(object):
     @property
     def green_green6(self):
         cname = "green_green6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_green6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12578,7 +12579,7 @@ class Cmaps(object):
     @property
     def green_green6_r(self):
         cname = "green_green6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_green6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12588,7 +12589,7 @@ class Cmaps(object):
     @property
     def green_mistyteal(self):
         cname = "green_mistyteal"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_mistyteal.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12598,7 +12599,7 @@ class Cmaps(object):
     @property
     def green_mistyteal_r(self):
         cname = "green_mistyteal_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_mistyteal.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12608,7 +12609,7 @@ class Cmaps(object):
     @property
     def green_mustard(self):
         cname = "green_mustard"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_mustard.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12618,7 +12619,7 @@ class Cmaps(object):
     @property
     def green_mustard_r(self):
         cname = "green_mustard_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_mustard.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12628,7 +12629,7 @@ class Cmaps(object):
     @property
     def green_rox(self):
         cname = "green_rox"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_rox.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12638,7 +12639,7 @@ class Cmaps(object):
     @property
     def green_rox_r(self):
         cname = "green_rox_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "green_rox.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12648,7 +12649,7 @@ class Cmaps(object):
     @property
     def hier1p(self):
         cname = "hier1p"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier1p.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12658,7 +12659,7 @@ class Cmaps(object):
     @property
     def hier1p_r(self):
         cname = "hier1p_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier1p.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12668,7 +12669,7 @@ class Cmaps(object):
     @property
     def hier2p(self):
         cname = "hier2p"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier2p.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12678,7 +12679,7 @@ class Cmaps(object):
     @property
     def hier2p_r(self):
         cname = "hier2p_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier2p.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12688,7 +12689,7 @@ class Cmaps(object):
     @property
     def hier4w(self):
         cname = "hier4w"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier4w.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12698,7 +12699,7 @@ class Cmaps(object):
     @property
     def hier4w_r(self):
         cname = "hier4w_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier4w.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12708,7 +12709,7 @@ class Cmaps(object):
     @property
     def hier5(self):
         cname = "hier5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12718,7 +12719,7 @@ class Cmaps(object):
     @property
     def hier5_r(self):
         cname = "hier5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hier5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12728,7 +12729,7 @@ class Cmaps(object):
     @property
     def high2ml(self):
         cname = "high2ml"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high2ml.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12738,7 +12739,7 @@ class Cmaps(object):
     @property
     def high2ml_r(self):
         cname = "high2ml_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high2ml.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12748,7 +12749,7 @@ class Cmaps(object):
     @property
     def high3(self):
         cname = "high3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12758,7 +12759,7 @@ class Cmaps(object):
     @property
     def high3_r(self):
         cname = "high3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12768,7 +12769,7 @@ class Cmaps(object):
     @property
     def high4(self):
         cname = "high4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12778,7 +12779,7 @@ class Cmaps(object):
     @property
     def high4_r(self):
         cname = "high4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12788,7 +12789,7 @@ class Cmaps(object):
     @property
     def high5(self):
         cname = "high5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12798,7 +12799,7 @@ class Cmaps(object):
     @property
     def high5_r(self):
         cname = "high5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "high5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12808,7 +12809,7 @@ class Cmaps(object):
     @property
     def hs_orange2(self):
         cname = "hs_orange2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hs_orange2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12818,7 +12819,7 @@ class Cmaps(object):
     @property
     def hs_orange2_r(self):
         cname = "hs_orange2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "hs_orange2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12828,7 +12829,7 @@ class Cmaps(object):
     @property
     def l_oragnemed1(self):
         cname = "l_oragnemed1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_oragnemed1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12838,7 +12839,7 @@ class Cmaps(object):
     @property
     def l_oragnemed1_r(self):
         cname = "l_oragnemed1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_oragnemed1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12848,7 +12849,7 @@ class Cmaps(object):
     @property
     def l_orangemute1(self):
         cname = "l_orangemute1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_orangemute1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12858,7 +12859,7 @@ class Cmaps(object):
     @property
     def l_orangemute1_r(self):
         cname = "l_orangemute1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_orangemute1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12868,7 +12869,7 @@ class Cmaps(object):
     @property
     def l_orangesat1(self):
         cname = "l_orangesat1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_orangesat1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12878,7 +12879,7 @@ class Cmaps(object):
     @property
     def l_orangesat1_r(self):
         cname = "l_orangesat1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_orangesat1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12888,7 +12889,7 @@ class Cmaps(object):
     @property
     def l_purplowsat3(self):
         cname = "l_purplowsat3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_purplowsat3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12898,7 +12899,7 @@ class Cmaps(object):
     @property
     def l_purplowsat3_r(self):
         cname = "l_purplowsat3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_purplowsat3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12908,7 +12909,7 @@ class Cmaps(object):
     @property
     def l_purpmedsat3(self):
         cname = "l_purpmedsat3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_purpmedsat3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12918,7 +12919,7 @@ class Cmaps(object):
     @property
     def l_purpmedsat3_r(self):
         cname = "l_purpmedsat3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_purpmedsat3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12928,7 +12929,7 @@ class Cmaps(object):
     @property
     def l_purpwarm2(self):
         cname = "l_purpwarm2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_purpwarm2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12938,7 +12939,7 @@ class Cmaps(object):
     @property
     def l_purpwarm2_r(self):
         cname = "l_purpwarm2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_purpwarm2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12948,7 +12949,7 @@ class Cmaps(object):
     @property
     def l_red_warm1(self):
         cname = "l_red_warm1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_red_warm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12958,7 +12959,7 @@ class Cmaps(object):
     @property
     def l_red_warm1_r(self):
         cname = "l_red_warm1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_red_warm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12968,7 +12969,7 @@ class Cmaps(object):
     @property
     def l_redmuted4(self):
         cname = "l_redmuted4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_redmuted4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12978,7 +12979,7 @@ class Cmaps(object):
     @property
     def l_redmuted4_r(self):
         cname = "l_redmuted4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_redmuted4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -12988,7 +12989,7 @@ class Cmaps(object):
     @property
     def l_redsat1(self):
         cname = "l_redsat1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_redsat1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -12998,7 +12999,7 @@ class Cmaps(object):
     @property
     def l_redsat1_r(self):
         cname = "l_redsat1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_redsat1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13008,7 +13009,7 @@ class Cmaps(object):
     @property
     def l_turqmed2(self):
         cname = "l_turqmed2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_turqmed2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13018,7 +13019,7 @@ class Cmaps(object):
     @property
     def l_turqmed2_r(self):
         cname = "l_turqmed2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_turqmed2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13028,7 +13029,7 @@ class Cmaps(object):
     @property
     def l_turqsat1(self):
         cname = "l_turqsat1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_turqsat1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13038,7 +13039,7 @@ class Cmaps(object):
     @property
     def l_turqsat1_r(self):
         cname = "l_turqsat1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_turqsat1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13048,7 +13049,7 @@ class Cmaps(object):
     @property
     def l_yellowmed2(self):
         cname = "l_yellowmed2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_yellowmed2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13058,7 +13059,7 @@ class Cmaps(object):
     @property
     def l_yellowmed2_r(self):
         cname = "l_yellowmed2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "l_yellowmed2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13068,7 +13069,7 @@ class Cmaps(object):
     @property
     def mauve1(self):
         cname = "mauve1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "mauve1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13078,7 +13079,7 @@ class Cmaps(object):
     @property
     def mauve1_r(self):
         cname = "mauve1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "mauve1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13088,7 +13089,7 @@ class Cmaps(object):
     @property
     def oryell2(self):
         cname = "oryell2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "oryell2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13098,7 +13099,7 @@ class Cmaps(object):
     @property
     def oryell2_r(self):
         cname = "oryell2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "oryell2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13108,7 +13109,7 @@ class Cmaps(object):
     @property
     def other_outl_1(self):
         cname = "other_outl_1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13118,7 +13119,7 @@ class Cmaps(object):
     @property
     def other_outl_1_r(self):
         cname = "other_outl_1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13128,7 +13129,7 @@ class Cmaps(object):
     @property
     def other_outl_2(self):
         cname = "other_outl_2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13138,7 +13139,7 @@ class Cmaps(object):
     @property
     def other_outl_2_r(self):
         cname = "other_outl_2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13148,7 +13149,7 @@ class Cmaps(object):
     @property
     def other_outl_3(self):
         cname = "other_outl_3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13158,7 +13159,7 @@ class Cmaps(object):
     @property
     def other_outl_3_r(self):
         cname = "other_outl_3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13168,7 +13169,7 @@ class Cmaps(object):
     @property
     def other_outl_4(self):
         cname = "other_outl_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13178,7 +13179,7 @@ class Cmaps(object):
     @property
     def other_outl_4_r(self):
         cname = "other_outl_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13188,7 +13189,7 @@ class Cmaps(object):
     @property
     def other_outl_5(self):
         cname = "other_outl_5"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13198,7 +13199,7 @@ class Cmaps(object):
     @property
     def other_outl_5_r(self):
         cname = "other_outl_5_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_5.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13208,7 +13209,7 @@ class Cmaps(object):
     @property
     def other_outl_6(self):
         cname = "other_outl_6"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13218,7 +13219,7 @@ class Cmaps(object):
     @property
     def other_outl_6_r(self):
         cname = "other_outl_6_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_6.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13228,7 +13229,7 @@ class Cmaps(object):
     @property
     def other_outl_7(self):
         cname = "other_outl_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13238,7 +13239,7 @@ class Cmaps(object):
     @property
     def other_outl_7_r(self):
         cname = "other_outl_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13248,7 +13249,7 @@ class Cmaps(object):
     @property
     def other_outl_8(self):
         cname = "other_outl_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13258,7 +13259,7 @@ class Cmaps(object):
     @property
     def other_outl_8_r(self):
         cname = "other_outl_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "other_outl_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13268,7 +13269,7 @@ class Cmaps(object):
     @property
     def pr_mist(self):
         cname = "pr_mist"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "pr_mist.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13278,7 +13279,7 @@ class Cmaps(object):
     @property
     def pr_mist_r(self):
         cname = "pr_mist_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "pr_mist.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13288,7 +13289,7 @@ class Cmaps(object):
     @property
     def purp2(self):
         cname = "purp2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "purp2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13298,7 +13299,7 @@ class Cmaps(object):
     @property
     def purp2_r(self):
         cname = "purp2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "purp2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13308,7 +13309,7 @@ class Cmaps(object):
     @property
     def purp_pink(self):
         cname = "purp_pink"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "purp_pink.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13318,7 +13319,7 @@ class Cmaps(object):
     @property
     def purp_pink_r(self):
         cname = "purp_pink_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "purp_pink.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13328,7 +13329,7 @@ class Cmaps(object):
     @property
     def red2b(self):
         cname = "red2b"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "red2b.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13338,7 +13339,7 @@ class Cmaps(object):
     @property
     def red2b_r(self):
         cname = "red2b_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "red2b.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13348,7 +13349,7 @@ class Cmaps(object):
     @property
     def red_1lt(self):
         cname = "red_1lt"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "red_1lt.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13358,7 +13359,7 @@ class Cmaps(object):
     @property
     def red_1lt_r(self):
         cname = "red_1lt_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "red_1lt.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13368,7 +13369,7 @@ class Cmaps(object):
     @property
     def redp1(self):
         cname = "redp1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "redp1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13378,7 +13379,7 @@ class Cmaps(object):
     @property
     def redp1_r(self):
         cname = "redp1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "redp1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13388,7 +13389,7 @@ class Cmaps(object):
     @property
     def redsun1(self):
         cname = "redsun1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "redsun1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13398,7 +13399,7 @@ class Cmaps(object):
     @property
     def redsun1_r(self):
         cname = "redsun1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "redsun1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13408,7 +13409,7 @@ class Cmaps(object):
     @property
     def redy3(self):
         cname = "redy3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "redy3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13418,7 +13419,7 @@ class Cmaps(object):
     @property
     def redy3_r(self):
         cname = "redy3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "redy3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13428,7 +13429,7 @@ class Cmaps(object):
     @property
     def rpinky(self):
         cname = "rpinky"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "rpinky.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13438,7 +13439,7 @@ class Cmaps(object):
     @property
     def rpinky_r(self):
         cname = "rpinky_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "rpinky.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13448,7 +13449,7 @@ class Cmaps(object):
     @property
     def speed_yel(self):
         cname = "speed_yel"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "speed_yel.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13458,7 +13459,7 @@ class Cmaps(object):
     @property
     def speed_yel_r(self):
         cname = "speed_yel_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "speed_yel.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13468,7 +13469,7 @@ class Cmaps(object):
     @property
     def tempm1(self):
         cname = "tempm1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "tempm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13478,7 +13479,7 @@ class Cmaps(object):
     @property
     def tempm1_r(self):
         cname = "tempm1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "tempm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13488,7 +13489,7 @@ class Cmaps(object):
     @property
     def test(self):
         cname = "test"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "test.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13498,7 +13499,7 @@ class Cmaps(object):
     @property
     def test_r(self):
         cname = "test_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "test.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13508,7 +13509,7 @@ class Cmaps(object):
     @property
     def tr4(self):
         cname = "tr4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "tr4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13518,7 +13519,7 @@ class Cmaps(object):
     @property
     def tr4_r(self):
         cname = "tr4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "tr4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13528,7 +13529,7 @@ class Cmaps(object):
     @property
     def turq1lt(self):
         cname = "turq1lt"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "turq1lt.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13538,7 +13539,7 @@ class Cmaps(object):
     @property
     def turq1lt_r(self):
         cname = "turq1lt_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "turq1lt.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13548,7 +13549,7 @@ class Cmaps(object):
     @property
     def turqw1(self):
         cname = "turqw1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "turqw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13558,7 +13559,7 @@ class Cmaps(object):
     @property
     def turqw1_r(self):
         cname = "turqw1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "turqw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13568,7 +13569,7 @@ class Cmaps(object):
     @property
     def vvlt_turq3(self):
         cname = "vvlt_turq3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "vvlt_turq3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13578,7 +13579,7 @@ class Cmaps(object):
     @property
     def vvlt_turq3_r(self):
         cname = "vvlt_turq3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "vvlt_turq3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13588,7 +13589,7 @@ class Cmaps(object):
     @property
     def w5m4(self):
         cname = "w5m4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "w5m4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13598,7 +13599,7 @@ class Cmaps(object):
     @property
     def w5m4_r(self):
         cname = "w5m4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "w5m4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13608,7 +13609,7 @@ class Cmaps(object):
     @property
     def w_ymiddle1(self):
         cname = "w_ymiddle1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "w_ymiddle1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13618,7 +13619,7 @@ class Cmaps(object):
     @property
     def w_ymiddle1_r(self):
         cname = "w_ymiddle1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "w_ymiddle1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13628,7 +13629,7 @@ class Cmaps(object):
     @property
     def wlteqcool(self):
         cname = "wlteqcool"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "wlteqcool.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13638,7 +13639,7 @@ class Cmaps(object):
     @property
     def wlteqcool_r(self):
         cname = "wlteqcool_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "wlteqcool.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13648,7 +13649,7 @@ class Cmaps(object):
     @property
     def wmutedset(self):
         cname = "wmutedset"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "wmutedset.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13658,7 +13659,7 @@ class Cmaps(object):
     @property
     def wmutedset_r(self):
         cname = "wmutedset_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "wmutedset.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13668,7 +13669,7 @@ class Cmaps(object):
     @property
     def yel15(self):
         cname = "yel15"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yel15.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13678,7 +13679,7 @@ class Cmaps(object):
     @property
     def yel15_r(self):
         cname = "yel15_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yel15.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13688,7 +13689,7 @@ class Cmaps(object):
     @property
     def yel3(self):
         cname = "yel3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yel3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13698,7 +13699,7 @@ class Cmaps(object):
     @property
     def yel3_r(self):
         cname = "yel3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yel3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13708,7 +13709,7 @@ class Cmaps(object):
     @property
     def yel_peach_br(self):
         cname = "yel_peach_br"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yel_peach_br.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13718,7 +13719,7 @@ class Cmaps(object):
     @property
     def yel_peach_br_r(self):
         cname = "yel_peach_br_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yel_peach_br.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13728,7 +13729,7 @@ class Cmaps(object):
     @property
     def yellowsun(self):
         cname = "yellowsun"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yellowsun.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13738,7 +13739,7 @@ class Cmaps(object):
     @property
     def yellowsun_r(self):
         cname = "yellowsun_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yellowsun.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13748,7 +13749,7 @@ class Cmaps(object):
     @property
     def yelsat100(self):
         cname = "yelsat100"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yelsat100.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13758,7 +13759,7 @@ class Cmaps(object):
     @property
     def yelsat100_r(self):
         cname = "yelsat100_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yelsat100.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13768,7 +13769,7 @@ class Cmaps(object):
     @property
     def yg1(self):
         cname = "yg1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yg1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13778,7 +13779,7 @@ class Cmaps(object):
     @property
     def yg1_r(self):
         cname = "yg1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yg1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13788,7 +13789,7 @@ class Cmaps(object):
     @property
     def yg3(self):
         cname = "yg3"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yg3.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13798,7 +13799,7 @@ class Cmaps(object):
     @property
     def yg3_r(self):
         cname = "yg3_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "sciviz",  "yg3.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13808,7 +13809,7 @@ class Cmaps(object):
     @property
     def cet_c_grey(self):
         cname = "cet_c_grey"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_grey.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13818,7 +13819,7 @@ class Cmaps(object):
     @property
     def cet_c_grey_r(self):
         cname = "cet_c_grey_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_grey.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13828,7 +13829,7 @@ class Cmaps(object):
     @property
     def cet_c_grey_15(self):
         cname = "cet_c_grey_15"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_grey_15.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13838,7 +13839,7 @@ class Cmaps(object):
     @property
     def cet_c_grey_15_r(self):
         cname = "cet_c_grey_15_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_grey_15.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13848,7 +13849,7 @@ class Cmaps(object):
     @property
     def cet_c_mrybm(self):
         cname = "cet_c_mrybm"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mrybm.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13858,7 +13859,7 @@ class Cmaps(object):
     @property
     def cet_c_mrybm_r(self):
         cname = "cet_c_mrybm_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mrybm.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13868,7 +13869,7 @@ class Cmaps(object):
     @property
     def cet_c_mrybm_35(self):
         cname = "cet_c_mrybm_35"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mrybm_35.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13878,7 +13879,7 @@ class Cmaps(object):
     @property
     def cet_c_mrybm_35_r(self):
         cname = "cet_c_mrybm_35_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mrybm_35.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13888,7 +13889,7 @@ class Cmaps(object):
     @property
     def cet_c_mygbm(self):
         cname = "cet_c_mygbm"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mygbm.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13898,7 +13899,7 @@ class Cmaps(object):
     @property
     def cet_c_mygbm_r(self):
         cname = "cet_c_mygbm_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mygbm.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13908,7 +13909,7 @@ class Cmaps(object):
     @property
     def cet_c_mygbm_30(self):
         cname = "cet_c_mygbm_30"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mygbm_30.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13918,7 +13919,7 @@ class Cmaps(object):
     @property
     def cet_c_mygbm_30_r(self):
         cname = "cet_c_mygbm_30_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_mygbm_30.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13928,7 +13929,7 @@ class Cmaps(object):
     @property
     def cet_c_protanopic_deuteranopic_bwyk(self):
         cname = "cet_c_protanopic_deuteranopic_bwyk"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_protanopic_deuteranopic_bwyk.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13938,7 +13939,7 @@ class Cmaps(object):
     @property
     def cet_c_protanopic_deuteranopic_bwyk_r(self):
         cname = "cet_c_protanopic_deuteranopic_bwyk_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_protanopic_deuteranopic_bwyk.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13948,7 +13949,7 @@ class Cmaps(object):
     @property
     def cet_c_protanopic_deuteranopic_wywb(self):
         cname = "cet_c_protanopic_deuteranopic_wywb"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_protanopic_deuteranopic_wywb.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13958,7 +13959,7 @@ class Cmaps(object):
     @property
     def cet_c_protanopic_deuteranopic_wywb_r(self):
         cname = "cet_c_protanopic_deuteranopic_wywb_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_protanopic_deuteranopic_wywb.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13968,7 +13969,7 @@ class Cmaps(object):
     @property
     def cet_c_tritanopic_cwrk_4(self):
         cname = "cet_c_tritanopic_cwrk_4"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_tritanopic_cwrk_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13978,7 +13979,7 @@ class Cmaps(object):
     @property
     def cet_c_tritanopic_cwrk_4_r(self):
         cname = "cet_c_tritanopic_cwrk_4_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_tritanopic_cwrk_4.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -13988,7 +13989,7 @@ class Cmaps(object):
     @property
     def cet_c_tritanopic_wrwc_7(self):
         cname = "cet_c_tritanopic_wrwc_7"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_tritanopic_wrwc_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -13998,7 +13999,7 @@ class Cmaps(object):
     @property
     def cet_c_tritanopic_wrwc_7_r(self):
         cname = "cet_c_tritanopic_wrwc_7_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_tritanopic_wrwc_7.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14008,7 +14009,7 @@ class Cmaps(object):
     @property
     def cet_c_wrwbw(self):
         cname = "cet_c_wrwbw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_wrwbw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14018,7 +14019,7 @@ class Cmaps(object):
     @property
     def cet_c_wrwbw_r(self):
         cname = "cet_c_wrwbw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_wrwbw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14028,7 +14029,7 @@ class Cmaps(object):
     @property
     def cet_c_wrwbw_40(self):
         cname = "cet_c_wrwbw_40"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_wrwbw_40.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14038,7 +14039,7 @@ class Cmaps(object):
     @property
     def cet_c_wrwbw_40_r(self):
         cname = "cet_c_wrwbw_40_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_c_wrwbw_40.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14048,7 +14049,7 @@ class Cmaps(object):
     @property
     def cet_d_bkr(self):
         cname = "cet_d_bkr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bkr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14058,7 +14059,7 @@ class Cmaps(object):
     @property
     def cet_d_bkr_r(self):
         cname = "cet_d_bkr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bkr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14068,7 +14069,7 @@ class Cmaps(object):
     @property
     def cet_d_bky(self):
         cname = "cet_d_bky"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bky.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14078,7 +14079,7 @@ class Cmaps(object):
     @property
     def cet_d_bky_r(self):
         cname = "cet_d_bky_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bky.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14088,7 +14089,7 @@ class Cmaps(object):
     @property
     def cet_d_bwg(self):
         cname = "cet_d_bwg"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bwg.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14098,7 +14099,7 @@ class Cmaps(object):
     @property
     def cet_d_bwg_r(self):
         cname = "cet_d_bwg_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bwg.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14108,7 +14109,7 @@ class Cmaps(object):
     @property
     def cet_d_bwr(self):
         cname = "cet_d_bwr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bwr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14118,7 +14119,7 @@ class Cmaps(object):
     @property
     def cet_d_bwr_r(self):
         cname = "cet_d_bwr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_bwr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14128,7 +14129,7 @@ class Cmaps(object):
     @property
     def cet_d_cwm_8(self):
         cname = "cet_d_cwm_8"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_cwm_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14138,7 +14139,7 @@ class Cmaps(object):
     @property
     def cet_d_cwm_8_r(self):
         cname = "cet_d_cwm_8_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_cwm_8.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14148,7 +14149,7 @@ class Cmaps(object):
     @property
     def cet_d_gkr(self):
         cname = "cet_d_gkr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_gkr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14158,7 +14159,7 @@ class Cmaps(object):
     @property
     def cet_d_gkr_r(self):
         cname = "cet_d_gkr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_gkr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14168,7 +14169,7 @@ class Cmaps(object):
     @property
     def cet_d_gwr(self):
         cname = "cet_d_gwr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_gwr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14178,7 +14179,7 @@ class Cmaps(object):
     @property
     def cet_d_gwr_r(self):
         cname = "cet_d_gwr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_gwr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14188,7 +14189,7 @@ class Cmaps(object):
     @property
     def cet_d_gwv(self):
         cname = "cet_d_gwv"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_gwv.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14198,7 +14199,7 @@ class Cmaps(object):
     @property
     def cet_d_gwv_r(self):
         cname = "cet_d_gwv_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_gwv.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14208,7 +14209,7 @@ class Cmaps(object):
     @property
     def cet_d_isoluminant_cjm(self):
         cname = "cet_d_isoluminant_cjm"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_isoluminant_cjm.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14218,7 +14219,7 @@ class Cmaps(object):
     @property
     def cet_d_isoluminant_cjm_r(self):
         cname = "cet_d_isoluminant_cjm_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_isoluminant_cjm.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14228,7 +14229,7 @@ class Cmaps(object):
     @property
     def cet_d_isoluminant_cjm1(self):
         cname = "cet_d_isoluminant_cjm1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_isoluminant_cjm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14238,7 +14239,7 @@ class Cmaps(object):
     @property
     def cet_d_isoluminant_cjm1_r(self):
         cname = "cet_d_isoluminant_cjm1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_isoluminant_cjm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14248,7 +14249,7 @@ class Cmaps(object):
     @property
     def cet_d_isoluminant_cjo(self):
         cname = "cet_d_isoluminant_cjo"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_isoluminant_cjo.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14258,7 +14259,7 @@ class Cmaps(object):
     @property
     def cet_d_isoluminant_cjo_r(self):
         cname = "cet_d_isoluminant_cjo_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_isoluminant_cjo.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14268,7 +14269,7 @@ class Cmaps(object):
     @property
     def cet_d_linear_bjr(self):
         cname = "cet_d_linear_bjr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_linear_bjr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14278,7 +14279,7 @@ class Cmaps(object):
     @property
     def cet_d_linear_bjr_r(self):
         cname = "cet_d_linear_bjr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_linear_bjr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14288,7 +14289,7 @@ class Cmaps(object):
     @property
     def cet_d_linear_bjy(self):
         cname = "cet_d_linear_bjy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_linear_bjy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14298,7 +14299,7 @@ class Cmaps(object):
     @property
     def cet_d_linear_bjy_r(self):
         cname = "cet_d_linear_bjy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_linear_bjy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14308,7 +14309,7 @@ class Cmaps(object):
     @property
     def cet_d_protanopic_deuteranopic_bwy(self):
         cname = "cet_d_protanopic_deuteranopic_bwy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_protanopic_deuteranopic_bwy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14318,7 +14319,7 @@ class Cmaps(object):
     @property
     def cet_d_protanopic_deuteranopic_bwy_r(self):
         cname = "cet_d_protanopic_deuteranopic_bwy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_protanopic_deuteranopic_bwy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14328,7 +14329,7 @@ class Cmaps(object):
     @property
     def cet_d_rainbow_bgymr(self):
         cname = "cet_d_rainbow_bgymr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_rainbow_bgymr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14338,7 +14339,7 @@ class Cmaps(object):
     @property
     def cet_d_rainbow_bgymr_r(self):
         cname = "cet_d_rainbow_bgymr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_rainbow_bgymr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14348,7 +14349,7 @@ class Cmaps(object):
     @property
     def cet_d_tritanopic_cwr(self):
         cname = "cet_d_tritanopic_cwr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_tritanopic_cwr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14358,7 +14359,7 @@ class Cmaps(object):
     @property
     def cet_d_tritanopic_cwr_r(self):
         cname = "cet_d_tritanopic_cwr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_d_tritanopic_cwr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14368,7 +14369,7 @@ class Cmaps(object):
     @property
     def cet_g_bw(self):
         cname = "cet_g_bw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14378,7 +14379,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_r(self):
         cname = "cet_g_bw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14388,7 +14389,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc(self):
         cname = "cet_g_bw_minc"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14398,7 +14399,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc_r(self):
         cname = "cet_g_bw_minc_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14408,7 +14409,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc1(self):
         cname = "cet_g_bw_minc1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14418,7 +14419,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc1_r(self):
         cname = "cet_g_bw_minc1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14428,7 +14429,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc_maxl(self):
         cname = "cet_g_bw_minc_maxl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc_maxl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14438,7 +14439,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc_maxl_r(self):
         cname = "cet_g_bw_minc_maxl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc_maxl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14448,7 +14449,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc_minl(self):
         cname = "cet_g_bw_minc_minl"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc_minl.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14458,7 +14459,7 @@ class Cmaps(object):
     @property
     def cet_g_bw_minc_minl_r(self):
         cname = "cet_g_bw_minc_minl_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_bw_minc_minl.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14468,7 +14469,7 @@ class Cmaps(object):
     @property
     def cet_g_category10(self):
         cname = "cet_g_category10"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_category10.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14478,7 +14479,7 @@ class Cmaps(object):
     @property
     def cet_g_category10_r(self):
         cname = "cet_g_category10_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_category10.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14488,7 +14489,7 @@ class Cmaps(object):
     @property
     def cet_g_hv(self):
         cname = "cet_g_hv"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_hv.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14498,7 +14499,7 @@ class Cmaps(object):
     @property
     def cet_g_hv_r(self):
         cname = "cet_g_hv_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_g_hv.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14508,7 +14509,7 @@ class Cmaps(object):
     @property
     def cet_i(self):
         cname = "cet_i"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_i.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14518,7 +14519,7 @@ class Cmaps(object):
     @property
     def cet_i_r(self):
         cname = "cet_i_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_i.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14528,7 +14529,7 @@ class Cmaps(object):
     @property
     def cet_i_cgo(self):
         cname = "cet_i_cgo"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_i_cgo.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14538,7 +14539,7 @@ class Cmaps(object):
     @property
     def cet_i_cgo_r(self):
         cname = "cet_i_cgo_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_i_cgo.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14548,7 +14549,7 @@ class Cmaps(object):
     @property
     def cet_i_cgo1(self):
         cname = "cet_i_cgo1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_i_cgo1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14558,7 +14559,7 @@ class Cmaps(object):
     @property
     def cet_i_cgo1_r(self):
         cname = "cet_i_cgo1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_i_cgo1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14568,7 +14569,7 @@ class Cmaps(object):
     @property
     def cet_l_bgy(self):
         cname = "cet_l_bgy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bgy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14578,7 +14579,7 @@ class Cmaps(object):
     @property
     def cet_l_bgy_r(self):
         cname = "cet_l_bgy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bgy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14588,7 +14589,7 @@ class Cmaps(object):
     @property
     def cet_l_bgyw(self):
         cname = "cet_l_bgyw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bgyw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14598,7 +14599,7 @@ class Cmaps(object):
     @property
     def cet_l_bgyw_r(self):
         cname = "cet_l_bgyw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bgyw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14608,7 +14609,7 @@ class Cmaps(object):
     @property
     def cet_l_bgyw1(self):
         cname = "cet_l_bgyw1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bgyw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14618,7 +14619,7 @@ class Cmaps(object):
     @property
     def cet_l_bgyw1_r(self):
         cname = "cet_l_bgyw1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bgyw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14628,7 +14629,7 @@ class Cmaps(object):
     @property
     def cet_l_blue(self):
         cname = "cet_l_blue"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_blue.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14638,7 +14639,7 @@ class Cmaps(object):
     @property
     def cet_l_blue_r(self):
         cname = "cet_l_blue_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_blue.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14648,7 +14649,7 @@ class Cmaps(object):
     @property
     def cet_l_blue1(self):
         cname = "cet_l_blue1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_blue1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14658,7 +14659,7 @@ class Cmaps(object):
     @property
     def cet_l_blue1_r(self):
         cname = "cet_l_blue1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_blue1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14668,7 +14669,7 @@ class Cmaps(object):
     @property
     def cet_l_bmw(self):
         cname = "cet_l_bmw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14678,7 +14679,7 @@ class Cmaps(object):
     @property
     def cet_l_bmw_r(self):
         cname = "cet_l_bmw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14688,7 +14689,7 @@ class Cmaps(object):
     @property
     def cet_l_bmw1(self):
         cname = "cet_l_bmw1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14698,7 +14699,7 @@ class Cmaps(object):
     @property
     def cet_l_bmw1_r(self):
         cname = "cet_l_bmw1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14708,7 +14709,7 @@ class Cmaps(object):
     @property
     def cet_l_bmy(self):
         cname = "cet_l_bmy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14718,7 +14719,7 @@ class Cmaps(object):
     @property
     def cet_l_bmy_r(self):
         cname = "cet_l_bmy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14728,7 +14729,7 @@ class Cmaps(object):
     @property
     def cet_l_bmy1(self):
         cname = "cet_l_bmy1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmy1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14738,7 +14739,7 @@ class Cmaps(object):
     @property
     def cet_l_bmy1_r(self):
         cname = "cet_l_bmy1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_bmy1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14748,7 +14749,7 @@ class Cmaps(object):
     @property
     def cet_l_gow(self):
         cname = "cet_l_gow"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_gow.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14758,7 +14759,7 @@ class Cmaps(object):
     @property
     def cet_l_gow_r(self):
         cname = "cet_l_gow_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_gow.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14768,7 +14769,7 @@ class Cmaps(object):
     @property
     def cet_l_gow1(self):
         cname = "cet_l_gow1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_gow1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14778,7 +14779,7 @@ class Cmaps(object):
     @property
     def cet_l_gow1_r(self):
         cname = "cet_l_gow1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_gow1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14788,7 +14789,7 @@ class Cmaps(object):
     @property
     def cet_l_green(self):
         cname = "cet_l_green"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_green.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14798,7 +14799,7 @@ class Cmaps(object):
     @property
     def cet_l_green_r(self):
         cname = "cet_l_green_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_green.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14808,7 +14809,7 @@ class Cmaps(object):
     @property
     def cet_l_grey(self):
         cname = "cet_l_grey"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_grey.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14818,7 +14819,7 @@ class Cmaps(object):
     @property
     def cet_l_grey_r(self):
         cname = "cet_l_grey_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_grey.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14828,7 +14829,7 @@ class Cmaps(object):
     @property
     def cet_l_grey1(self):
         cname = "cet_l_grey1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_grey1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14838,7 +14839,7 @@ class Cmaps(object):
     @property
     def cet_l_grey1_r(self):
         cname = "cet_l_grey1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_grey1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14848,7 +14849,7 @@ class Cmaps(object):
     @property
     def cet_l_kbc(self):
         cname = "cet_l_kbc"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kbc.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14858,7 +14859,7 @@ class Cmaps(object):
     @property
     def cet_l_kbc_r(self):
         cname = "cet_l_kbc_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kbc.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14868,7 +14869,7 @@ class Cmaps(object):
     @property
     def cet_l_kbgyw(self):
         cname = "cet_l_kbgyw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kbgyw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14878,7 +14879,7 @@ class Cmaps(object):
     @property
     def cet_l_kbgyw_r(self):
         cname = "cet_l_kbgyw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kbgyw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14888,7 +14889,7 @@ class Cmaps(object):
     @property
     def cet_l_kgy(self):
         cname = "cet_l_kgy"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kgy.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14898,7 +14899,7 @@ class Cmaps(object):
     @property
     def cet_l_kgy_r(self):
         cname = "cet_l_kgy_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kgy.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14908,7 +14909,7 @@ class Cmaps(object):
     @property
     def cet_l_kry(self):
         cname = "cet_l_kry"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kry.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14918,7 +14919,7 @@ class Cmaps(object):
     @property
     def cet_l_kry_r(self):
         cname = "cet_l_kry_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kry.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14928,7 +14929,7 @@ class Cmaps(object):
     @property
     def cet_l_kry1(self):
         cname = "cet_l_kry1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kry1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14938,7 +14939,7 @@ class Cmaps(object):
     @property
     def cet_l_kry1_r(self):
         cname = "cet_l_kry1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kry1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14948,7 +14949,7 @@ class Cmaps(object):
     @property
     def cet_l_kry2(self):
         cname = "cet_l_kry2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kry2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14958,7 +14959,7 @@ class Cmaps(object):
     @property
     def cet_l_kry2_r(self):
         cname = "cet_l_kry2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kry2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14968,7 +14969,7 @@ class Cmaps(object):
     @property
     def cet_l_kryw(self):
         cname = "cet_l_kryw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kryw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14978,7 +14979,7 @@ class Cmaps(object):
     @property
     def cet_l_kryw_r(self):
         cname = "cet_l_kryw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kryw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -14988,7 +14989,7 @@ class Cmaps(object):
     @property
     def cet_l_kryw1(self):
         cname = "cet_l_kryw1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kryw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -14998,7 +14999,7 @@ class Cmaps(object):
     @property
     def cet_l_kryw1_r(self):
         cname = "cet_l_kryw1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kryw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15008,7 +15009,7 @@ class Cmaps(object):
     @property
     def cet_l_kryw2(self):
         cname = "cet_l_kryw2"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kryw2.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15018,7 +15019,7 @@ class Cmaps(object):
     @property
     def cet_l_kryw2_r(self):
         cname = "cet_l_kryw2_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_kryw2.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15028,7 +15029,7 @@ class Cmaps(object):
     @property
     def cet_l_protanopic_deuteranopic_kbjyw(self):
         cname = "cet_l_protanopic_deuteranopic_kbjyw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_protanopic_deuteranopic_kbjyw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15038,7 +15039,7 @@ class Cmaps(object):
     @property
     def cet_l_protanopic_deuteranopic_kbjyw_r(self):
         cname = "cet_l_protanopic_deuteranopic_kbjyw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_protanopic_deuteranopic_kbjyw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15048,7 +15049,7 @@ class Cmaps(object):
     @property
     def cet_l_protanopic_deuteranopic_kbw(self):
         cname = "cet_l_protanopic_deuteranopic_kbw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_protanopic_deuteranopic_kbw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15058,7 +15059,7 @@ class Cmaps(object):
     @property
     def cet_l_protanopic_deuteranopic_kbw_r(self):
         cname = "cet_l_protanopic_deuteranopic_kbw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_protanopic_deuteranopic_kbw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15068,7 +15069,7 @@ class Cmaps(object):
     @property
     def cet_l_ternary_blue(self):
         cname = "cet_l_ternary_blue"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_ternary_blue.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15078,7 +15079,7 @@ class Cmaps(object):
     @property
     def cet_l_ternary_blue_r(self):
         cname = "cet_l_ternary_blue_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_ternary_blue.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15088,7 +15089,7 @@ class Cmaps(object):
     @property
     def cet_l_ternary_green(self):
         cname = "cet_l_ternary_green"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_ternary_green.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15098,7 +15099,7 @@ class Cmaps(object):
     @property
     def cet_l_ternary_green_r(self):
         cname = "cet_l_ternary_green_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_ternary_green.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15108,7 +15109,7 @@ class Cmaps(object):
     @property
     def cet_l_ternary_red(self):
         cname = "cet_l_ternary_red"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_ternary_red.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15118,7 +15119,7 @@ class Cmaps(object):
     @property
     def cet_l_ternary_red_r(self):
         cname = "cet_l_ternary_red_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_ternary_red.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15128,7 +15129,7 @@ class Cmaps(object):
     @property
     def cet_l_tritanopic_krjcw(self):
         cname = "cet_l_tritanopic_krjcw"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_tritanopic_krjcw.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15138,7 +15139,7 @@ class Cmaps(object):
     @property
     def cet_l_tritanopic_krjcw_r(self):
         cname = "cet_l_tritanopic_krjcw_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_tritanopic_krjcw.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15148,7 +15149,7 @@ class Cmaps(object):
     @property
     def cet_l_tritanopic_krjcw1(self):
         cname = "cet_l_tritanopic_krjcw1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_tritanopic_krjcw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15158,7 +15159,7 @@ class Cmaps(object):
     @property
     def cet_l_tritanopic_krjcw1_r(self):
         cname = "cet_l_tritanopic_krjcw1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_tritanopic_krjcw1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15168,7 +15169,7 @@ class Cmaps(object):
     @property
     def cet_l_wcmr(self):
         cname = "cet_l_wcmr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_wcmr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15178,7 +15179,7 @@ class Cmaps(object):
     @property
     def cet_l_wcmr_r(self):
         cname = "cet_l_wcmr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_wcmr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15188,7 +15189,7 @@ class Cmaps(object):
     @property
     def cet_l_worb(self):
         cname = "cet_l_worb"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_worb.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15198,7 +15199,7 @@ class Cmaps(object):
     @property
     def cet_l_worb_r(self):
         cname = "cet_l_worb_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_worb.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15208,7 +15209,7 @@ class Cmaps(object):
     @property
     def cet_l_wyor(self):
         cname = "cet_l_wyor"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_wyor.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15218,7 +15219,7 @@ class Cmaps(object):
     @property
     def cet_l_wyor_r(self):
         cname = "cet_l_wyor_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_l_wyor.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15228,7 +15229,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyr(self):
         cname = "cet_r_bgyr"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyr.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15238,7 +15239,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyr_r(self):
         cname = "cet_r_bgyr_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyr.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15248,7 +15249,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyr1(self):
         cname = "cet_r_bgyr1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyr1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15258,7 +15259,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyr1_r(self):
         cname = "cet_r_bgyr1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyr1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15268,7 +15269,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyrm(self):
         cname = "cet_r_bgyrm"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyrm.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15278,7 +15279,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyrm_r(self):
         cname = "cet_r_bgyrm_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyrm.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)
@@ -15288,7 +15289,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyrm1(self):
         cname = "cet_r_bgyrm1"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyrm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file), name=cname)
@@ -15298,7 +15299,7 @@ class Cmaps(object):
     @property
     def cet_r_bgyrm1_r(self):
         cname = "cet_r_bgyrm1_r"
-        if cname in matplotlib.cm._cmap_registry:
+        if cname in plt.colormaps():
             return matplotlib.cm.get_cmap(cname)
         cmap_file = os.path.join(CMAPSFILE_DIR, "colorcet",  "cet_r_bgyrm1.rgb")
         cmap = Colormap(self._coltbl(cmap_file)[::-1], name=cname)


### PR DESCRIPTION
Solve `_cmap_registry` error due to match with latest matplotlib version. Solves the problem reported at https://github.com/pratiman-91/colormaps/issues/1